### PR TITLE
Don't match JavaScript comments and strings when removing script tags.

### DIFF
--- a/Embed/Url.php
+++ b/Embed/Url.php
@@ -153,10 +153,10 @@ class Url {
 					$response = mb_convert_encoding($response, 'HTML-ENTITIES', 'UTF-8');
 					$response = preg_replace('/<head[^>]*>/','<head><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">', $response);
 				}
-
-				//Remove all script elements (thanks https://github.com/jasny)
-				$response = preg_replace('%<script\b(?:"(?:[^"\\\\\\\\]++|\\\\\\\\.)*+"|\'(?:[^\\\\\\\\]++|\\\\\\\\.)*+\'|[^>"]++)*>(?:"(?:[^"\\\\\\\\]++|\\\\\\\\.)*+"|\'(?:[^\\\\\\\\]++|\\\\\\\\.)*+\'|//.*?\n|/\*(?:[^\*]++|\*)*?\*/|[^<"/]++|/|(?R)|<)*?</\s*script>%si', '', $response);
-
+    
+				//Remove all script elements, CDATA sections and comments (thanks https://github.com/jasny)
+				$response = preg_replace(array('%<!--(?:[^-]++|-)*?-->|<!\[CDATA\[(?:[^\]]++|\])*?\]\]>%si', '%<script\b(?:"(?:[^"\\\\]++|\\\\.)*+"|\'(?:[^\'\\\\]++|\\\\.)*+\'|[^>"\']++)*>(?:[^<]++|<)*?</\s*script\s*>%si'), '', $response);
+                
 				$this->htmlContent->loadHTML($response);
 				libxml_use_internal_errors($errors);
 


### PR DESCRIPTION
First remove HTML comments and CDATA sections.
Next remove the script tags.

Fixes oscarotero/Embed#13
