### PR TITLE
Fix wrong call to mb_convert_encoding in resolve()

### DIFF
--- a/Embed/Url.php
+++ b/Embed/Url.php
@@ -69,7 +69,7 @@ class Url {
 			$charset = substr(strtoupper(strstr($charset, '=')), 1);
 
 			if (!empty($charset) && ($charset !== 'UTF-8')) {
-				@mb_convert_encoding($content, 'UTF-8', $charset);
+				$content = @mb_convert_encoding($content, 'UTF-8', $charset);
 			}
 		} else if (strpos($this->getResult('content_type'), '/') !== false) {
 			$this->result['mime_type'] = $this->getResult('content_type');


### PR DESCRIPTION
The charset is extracted from the ContentType, and mb_convert_encoding is called, but the actual $content is never converted to UTF-8 ($content is not passed by reference in this method).
