### PR TITLE
Fix the parser when path is empty

### DIFF
--- a/Embed/Url.php
+++ b/Embed/Url.php
@@ -416,7 +416,7 @@ class Url {
 	 * Return the url path
 	 */
 	public function getPath ($file = false) {
-		$path = isset($this->info['path']) ? '/'.implode('/', $this->info['path']).'/' : '/';
+		$path = isset($this->info['path']) && !empty($this->info['path']) ? '/'.implode('/', $this->info['path']).'/' : '/';
 
 		if ($file && !empty($this->info['file'])) {
 			$path .= $this->info['file'];

--- a/tests/EmbedTest.php
+++ b/tests/EmbedTest.php
@@ -81,4 +81,19 @@ class EmbedTest extends PHPUnit_Framework_TestCase {
 			)
 		);
 	}
+
+	public function testUrlParser()
+	{
+		$urls = array(
+			'http://vimeo.com//69912181?' => 'http://vimeo.com/69912181',
+			'http://vimeo.com//69912181' => 'http://vimeo.com/69912181',
+			'http://vimeo.com/69912181' => 'http://vimeo.com/69912181',
+		);
+
+		foreach ($urls as $url => $expected_url) {
+			$parsed_url = new Embed\Url($url);
+
+			$this->assertEquals($expected_url, $parsed_url->getUrl());
+		}
+	}
 }


### PR DESCRIPTION
For urls like `http://vimeo.com/69912181` or `http://jolicode.com/goodies`, the url parser was adding two `//` before the file name. This is a fix for this bug as well as new tests for it.
