### PR TITLE
array_unique failing on multidimensional array

### DIFF
--- a/src/Adapters/Soundcloud.php
+++ b/src/Adapters/Soundcloud.php
@@ -77,7 +77,7 @@ class Soundcloud extends Webpage implements AdapterInterface
             array_unshift($images, str_replace('-large.jpg', '-t500x500.jpg', $img));
         }
 
-        return array_unique($images);
+        return array_unique($images, SORT_REGULAR);
     }
 
     /**


### PR DESCRIPTION
I found a particular soundcloud URL that was causing array_unique to throw a warning in getImages() (called via getImage()).

For the url https://soundcloud.com/calumfoad/sets/flaws-ep-stream the condition on line 76 was triggered and the resulting $images array after array_unshift would cause a php Notice: Array to string conversion once array_unique was called as array_unique does not cope with multidimensional array unless SORT_REGULAR is passed.

In all the other urls I tested the condition on line 76 was not triggered and the array returned from parent::getImages(), whilst multidimensional, only had a single element, array_unique returns instantly when passed a single element array and so does not raise the Notice.

Here's a basic test case with soundcloud urls that do and don't trigger the warning (I'm using composer)

<?php
require_once('../vendor/autoload.php');

// This URL works fine
$info = Embed\Embed::create('http://www.soundcloud.com/bruceneilmusic');
$info->getImage();

// This url causes array_unique in getImages() to throw a warning
$info = Embed\Embed::create('https://soundcloud.com/calumfoad/sets/flaws-ep-stream');
$info->getImage();