### PR TITLE
Fix Instagram and Line.do tests

### DIFF
--- a/tests/InstagramTest.php
+++ b/tests/InstagramTest.php
@@ -10,7 +10,7 @@ class InstagramTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($info->imageHeight, 640);
         $this->assertEquals($info->type, 'rich');
         $this->assertEquals($info->authorName, 'agarzoniu');
-        $this->assertEquals($info->authorUrl, 'http://instagram.com/agarzoniu');
+        $this->assertEquals($info->authorUrl, 'https://instagram.com/agarzoniu');
         $this->assertEquals($info->providerName, 'Instagram');
     }
 }

--- a/tests/LineTest.php
+++ b/tests/LineTest.php
@@ -10,7 +10,7 @@ class LineTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($info->code, '<iframe src="https://line.do/embed/php-evolution/vertical" frameborder="0" allowTransparency="true" style="border:none;overflow:hidden;width:640px;height:640px;"></iframe>');
         $this->assertEquals($info->width, 640);
         $this->assertEquals($info->height, 640);
-        $this->assertEquals($info->providerName, 'line');
+        $this->assertEquals($info->providerName, 'Line.do');
         $this->assertEquals($info->providerUrl, 'https://line.do');
     }
 }


### PR DESCRIPTION
Just fix those tests for you. Yeah I'm frustrating when I see something red on a GitHub repo. :p

Errors was:
 
 * Wrong scheme for Instagram. Seems to be redirected to `https` by default.
 * Line.do provider name as changed. It's now `Line.do` instead of `line`.

Regards.