### PR TITLE
Feature/wordpress tv

### DIFF
--- a/src/Providers/OEmbed.php
+++ b/src/Providers/OEmbed.php
@@ -24,7 +24,7 @@ class OEmbed extends Provider implements ProviderInterface
         $endPoint = null;
         $params = $this->config['parameters'];
 
-        if (!($html = $this->request->getHtmlContent()) || !($endPoint = self::getEndPointFromDom($html))) {
+        if ($this->providerEmbedInDomIsBroken($this->request) || (!($html = $this->request->getHtmlContent()) || !($endPoint = self::getEndPointFromDom($html)))) {
             if (($info = self::getEndPointFromRequest($this->request, $this->config))) {
                 $endPoint = $info['endPoint'];
                 $params += $info['params'];
@@ -235,7 +235,7 @@ class OEmbed extends Provider implements ProviderInterface
     protected static function getEndPointFromRequest(Request $request, array $config)
     {
         //Search the oembed provider using the domain
-        $class = 'Embed\\Providers\\OEmbed\\'.str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $request->getDomain()))));
+        $class = self::getClassFromRequest($request);
 
         if (class_exists($class) && $request->match($class::getPatterns())) {
             return [
@@ -250,6 +250,24 @@ class OEmbed extends Provider implements ProviderInterface
                 'endPoint' => OEmbed\Embedly::getEndpoint(),
                 'params' => OEmbed\Embedly::getParams($request) + ['key' => $config['embedlyKey']],
             ];
+        }
+    }
+
+    /**
+     * Return the class name implementing an oEmbed provider
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected static function getClassFromRequest(Request $request) {
+        return 'Embed\\Providers\\OEmbed\\'.str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $request->getDomain()))));
+    }
+
+    protected static function providerEmbedInDomIsBroken(Request $request) {
+        $class = self::getClassFromRequest( $request );
+
+        if ( class_exists( $class ) && $request->match( $class::getPatterns() ) ) {
+            return $class::embedInDomIsBroken();
         }
     }
 }

--- a/src/Providers/OEmbed.php
+++ b/src/Providers/OEmbed.php
@@ -24,7 +24,7 @@ class OEmbed extends Provider implements ProviderInterface
         $endPoint = null;
         $params = $this->config['parameters'];
 
-        if ($this->providerEmbedInDomIsBroken($this->request) || (!($html = $this->request->getHtmlContent()) || !($endPoint = self::getEndPointFromDom($html)))) {
+        if (self::providerEmbedInDomIsBroken($this->request) || (!($html = $this->request->getHtmlContent()) || !($endPoint = self::getEndPointFromDom($html)))) {
             if (($info = self::getEndPointFromRequest($this->request, $this->config))) {
                 $endPoint = $info['endPoint'];
                 $params += $info['params'];

--- a/src/Providers/OEmbed.php
+++ b/src/Providers/OEmbed.php
@@ -263,6 +263,11 @@ class OEmbed extends Provider implements ProviderInterface
         return 'Embed\\Providers\\OEmbed\\'.str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $request->getDomain()))));
     }
 
+    /**
+     * @param Request $request
+     *
+     * @return bool
+     */
     protected static function providerEmbedInDomIsBroken(Request $request) {
         $class = self::getClassFromRequest( $request );
 

--- a/src/Providers/OEmbed.php
+++ b/src/Providers/OEmbed.php
@@ -269,5 +269,8 @@ class OEmbed extends Provider implements ProviderInterface
         if ( class_exists( $class ) && $request->match( $class::getPatterns() ) ) {
             return $class::embedInDomIsBroken();
         }
+
+        // Fall-through default in case this called for an invalid class
+        return false;
     }
 }

--- a/src/Providers/OEmbed/OEmbedImplementation.php
+++ b/src/Providers/OEmbed/OEmbedImplementation.php
@@ -39,4 +39,14 @@ abstract class OEmbedImplementation
     {
         return [];
     }
+
+    /**
+     * @access public
+     * @author Dave Ross
+     * @return bool
+     */
+    public static function embedInDomIsBroken()
+    {
+        return false;
+    }
 }

--- a/src/Providers/OEmbed/WordPress.php
+++ b/src/Providers/OEmbed/WordPress.php
@@ -1,0 +1,35 @@
+<?php
+namespace Embed\Providers\OEmbed;
+
+/**
+ * Class WordPress
+ * WordPress.tv embeds
+ * @package Embed\Providers\OEmbed
+ * @todo Class is named 'WordPress' to fit existing naming scheme, but could be confused with WordPress.com or WordPress.org
+ */
+class WordPress extends OEmbedImplementation
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function getEndPoint()
+	{
+		return 'https://wordpress.tv/oembed';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function getPatterns()
+	{
+		return ['https?://wordpress.tv/*'];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function embedInDomIsBroken()
+	{
+		return true;
+	}
+}

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -1,0 +1,16 @@
+<?php
+class WordPressTest extends PHPUnit_Framework_TestCase
+{
+	public function testOne()
+	{
+		$info = Embed\Embed::create('http://wordpress.tv/2013/09/06/dave-ross-optimize-image-files-like-a-pro/');
+
+		$this->assertEquals($info->title, 'Dave Ross: Optimize Image Files Like a Pro');
+		$this->assertEquals($info->imageWidth, 400);
+		$this->assertEquals($info->imageHeight, 224);
+		$this->assertEquals($info->type, 'video');
+		$this->assertEquals($info->authorName, '@WordPressTV');
+		$this->assertEquals($info->providerName, 'WordPress.tv');
+		$this->assertEquals($info->providerUrl, 'http://wordpress.tv');
+	}
+}


### PR DESCRIPTION
Adds support for WordPress.tv oEmbed. Also adds ```OEmbedImplementation::embedInDomIsBroken()``` to flag oEmbed providers whose ```application/json+oembed``` response isn't well-suited for embedding (returns full HTML page), but have a different oEmbed endpoint that is.