### PR TITLE
Fix #73 - Erroneous backslash slipping into 'path' on Windows

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -485,7 +485,7 @@ class Url
         $this->info['path'] = [];
 
         if (isset($parts['dirname'])) {
-            foreach (explode('/', $parts['dirname']) as $dir) {
+            foreach (explode(DIRECTORY_SEPARATOR, $parts['dirname']) as $dir) {
                 if ($dir !== '') {
                     $this->info['path'][] = $dir;
                 }


### PR DESCRIPTION
#73 was a platform problem.  Directory separators are backslashes on Windows, but the code was assuming they would always be forward slashes, hence an erroneous backslash was being added to the URL and everything fell over.