### PR TITLE
Add class to retrieve image-info with Guzzle5

### DIFF
--- a/src/ImageInfo/Guzzle5.php
+++ b/src/ImageInfo/Guzzle5.php
@@ -1,0 +1,38 @@
+<?php
+namespace Embed\ImageInfo;
+
+use Embed\ImageInfo\ImageInfoInterface;
+
+ /**
+  * Class to retrieve the size and mimetype of images using Guzzle5
+  */
+class Guzzle5 implements ImageInfoInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getImagesInfo(array $urls, array $config = null)
+    {
+        if ($config === null || !isset($config['client']) || !($config['client'] instanceof \GuzzleHttp\Client)) {
+            throw new RuntimeException('Guzzle client not passed in config.');
+        }
+
+        $client = $config['client'];
+        $result = [ ];
+
+        foreach ($urls as $url) {
+            $response = $client->get($url['value']);
+
+            if (($size = @getimagesizefromstring($response->getBody())) !== false) {
+                $result[] = [
+                    'width' => $size[0],
+                    'height' => $size[1],
+                    'size' => $size[0] * $size[1],
+                    'mime' => $response->getHeader('Content-Type'),
+                ] + $url;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/ImageInfo/Guzzle5.php
+++ b/src/ImageInfo/Guzzle5.php
@@ -36,7 +36,7 @@ class Guzzle5 implements ImageInfoInterface
                     'width' => $size[0],
                     'height' => $size[1],
                     'size' => $size[0] * $size[1],
-                    'mime' => $response->getHeader('Content-Type'),
+                    'mime' => $size['mime'],
                 ] + $urls[$i];
             }
         }

--- a/tests/ImageInfoTest.php
+++ b/tests/ImageInfoTest.php
@@ -24,7 +24,7 @@ class ImageInfoTest extends TestCaseBase
     public function testGuzzle()
     {
         $info = Embed\ImageInfo\Guzzle5::getImagesInfo([[
-            'value' => 'http://www.mixdecultura.ro/wp-content/uploads/2013/03/galicia-locuinte-celtice.jpg',
+            'value' => self::TEST_IMAGE_URL,
         ]], [
             'client' => new \GuzzleHttp\Client(),
         ]);

--- a/tests/ImageInfoTest.php
+++ b/tests/ImageInfoTest.php
@@ -1,17 +1,40 @@
 <?php
 class ImageInfoTest extends TestCaseBase
 {
+    const TEST_IMAGE_URL = 'http://www.mixdecultura.ro/wp-content/uploads/2013/03/galicia-locuinte-celtice.jpg';
+    const TEST_IMAGE_WIDTH = 600;
+    const TEST_IMAGE_HEIGHT = 408;
+    const TEST_IMAGE_SIZE = 244800;
+    const TEST_IMAGE_MIME = 'image/jpeg';
+
     public function testOne()
     {
         $info = Embed\ImageInfo\Curl::getImageInfo([
-            'value' => 'http://www.mixdecultura.ro/wp-content/uploads/2013/03/galicia-locuinte-celtice.jpg',
+            'value' => self::TEST_IMAGE_URL,
         ]);
 
         $this->assertEquals($info, [
-            'width' => 600,
-            'height' => 408,
-            'size' => 244800,
-            'mime' => 'image/jpeg',
+            'width' => self::TEST_IMAGE_WIDTH,
+            'height' => self::TEST_IMAGE_HEIGHT,
+            'size' => self::TEST_IMAGE_SIZE,
+            'mime' => self::TEST_IMAGE_MIME,
+        ]);
+    }
+
+    public function testGuzzle()
+    {
+        $info = Embed\ImageInfo\Guzzle5::getImagesInfo([[
+            'value' => 'http://www.mixdecultura.ro/wp-content/uploads/2013/03/galicia-locuinte-celtice.jpg',
+        ]], [
+            'client' => new \GuzzleHttp\Client(),
+        ]);
+
+        $this->assertEquals($info[0], [
+            'width' => self::TEST_IMAGE_WIDTH,
+            'height' => self::TEST_IMAGE_HEIGHT,
+            'size' => self::TEST_IMAGE_SIZE,
+            'mime' => self::TEST_IMAGE_MIME,
+            'value' => self::TEST_IMAGE_URL,
         ]);
     }
 }


### PR DESCRIPTION
This PR adds an additional class `Embed\ImageInfo\Guzzle` to retrieve image information. Takes the same configuration parameters (`client`) as `Embed\RequestResolvers\Guzzle5`.

I also added some constants in the `ImageInfoTest` class to avoid copy & paste.

Originally developed by @my-name for our private project.