### PR TITLE
Configuration of ImageInfo class must be passed correctly

### DIFF
--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -281,7 +281,7 @@ abstract class Adapter
      */
     public function getProviderIcons()
     {
-        return call_user_func("{$this->imageClass}::getImagesInfo", $this->getProviderIconsUrls());
+        return call_user_func("{$this->imageClass}::getImagesInfo", $this->getProviderIconsUrls(), $this->imageConfig);
     }
 
     /**


### PR DESCRIPTION
This fixes a bug where the `$config` parameter is not correctly passed to the `ImageInfoInterface` implementation from `Adapter`.

Bug can be reproduced by using the newly added `Guzzle5` image resolver class in the demo app (requires `$config["client"]` to be set)