### PR TITLE
Providers for domains starting with numerical 

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -34,7 +34,7 @@ class Embed
         }
 
         //Search the adapter using the domain
-        $adapter = 'Embed\\Adapters\\'.str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $request->getDomain()))));
+        $adapter = 'Embed\\Adapters\\'.$request->getClassNameForDomain();
 
         if (class_exists($adapter) && ($info = self::executeAdapter($adapter, $request, $config))) {
             return $info;

--- a/src/Providers/OEmbed.php
+++ b/src/Providers/OEmbed.php
@@ -263,7 +263,7 @@ class OEmbed extends Provider implements ProviderInterface
      */
     protected static function getClassFromRequest(Request $request)
     {
-        return 'Embed\\Providers\\OEmbed\\'.str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $request->getDomain()))));
+        return 'Embed\\Providers\\OEmbed\\'.$request->getClassNameForDomain();
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -120,6 +120,22 @@ class Request extends Url
     }
 
     /**
+     * Return ClassName for domain.
+     * 
+     * Domains started with numbers will get N prepended to their class name.
+     *
+     * @return string
+     */
+    public function getClassNameForDomain()
+    {
+        $className = str_replace(array('-',' '),'', ucwords(strtolower($this->getDomain())));
+        if (is_numeric(mb_substr($className, 0, 1)))
+            $className='N'.$className;
+
+        return $className;
+    }
+
+    /**
      * Return the http request info (for debug purposes).
      *
      * @return array

--- a/src/Request.php
+++ b/src/Request.php
@@ -130,8 +130,9 @@ class Request extends Url
     {
         $className = str_replace(array('-',' '),'', ucwords(strtolower($this->getDomain())));
         if (is_numeric(mb_substr($className, 0, 1)))
+        {
             $className='N'.$className;
-
+        }
         return $className;
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -129,8 +129,7 @@ class Request extends Url
     public function getClassNameForDomain()
     {
         $className = str_replace(array('-',' '),'', ucwords(strtolower($this->getDomain())));
-        if (is_numeric(mb_substr($className, 0, 1)))
-        {
+        if (is_numeric(mb_substr($className, 0, 1))) {
             $className='N'.$className;
         }
         return $className;


### PR DESCRIPTION
Hello, is there a normal way to add specific providers for domains starting with numbers. Like 2ch, 500px, etc.
Maybe domainresolver should check, and if domain starting with something inappropriate for classname it will prepend something like _ to it?
 