### PR TITLE
Parsed down the URL parameter which earlier allowed XSS on page

### DIFF
--- a/demo/index.php
+++ b/demo/index.php
@@ -6,6 +6,11 @@ include '../src/autoloader.php';
 
 function get($name, $default = '')
 {
+    if($name == 'url') {
+        if(filter_var($_GET['url'], FILTER_VALIDATE_URL)) {
+            return 'http://doNotTryToXSS.invalid';
+        }
+    }
     return isset($_GET[$name]) ? $_GET[$name] : $default;
 }
 


### PR DESCRIPTION
Visit this page before updating the website:

http://oscarotero.com/embed2/demo/index.php?url=%3Cimg%20src=x%20onerror=alert()%3E%20%3Ch1%20style=%22position:absolute;top:0;font-size:100px%22%3EThis%20is%20easily%20defaceable

It shows a message This is easily defaceable. If you disable your inbuilt XSS auditor, (ex-run in firefox), you can even execute arbitrary javascript on the frontend.
I've fixed that by checking if URL is actually a URL or not.