### PR TITLE
More complete support of URL parsing

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -415,6 +415,12 @@ class Url
             $url .= $this->info['scheme'].'://';
         }
 
+        $user = isset($this->info['user']) ? $this->info['user'] : '';
+        $pass = isset($this->info['pass']) ? ':' . $this->info['pass']  : '';
+        if ($user || $pass) {
+            $url .= $user . $pass . '@';
+        }
+
         if (isset($this->info['host'])) {
             $url .= $this->info['host'];
         }

--- a/src/Url.php
+++ b/src/Url.php
@@ -419,6 +419,10 @@ class Url
             $url .= $this->info['host'];
         }
 
+        if (isset($this->info['port'])) {
+            $url .= ':' . $this->info['port'];
+        }
+
         $url .= $this->getPath();
 
         if (!empty($this->info['query'])) {

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -15,6 +15,9 @@ class UrlTest extends TestCaseBase
             ['https://animoto.com/oembeds/create.xml?automated=true&options=start_hq', 'https://animoto.com/oembeds/create.xml?automated=true&options=start_hq'],
             ['http://static2.politico.com/dims4/default/28fb355/2147483647/resize/1160x%3E/quality/90/?url=http%3A%2F%2Fs3-origin-images.politico.com%2F2013%2F12%2F18%2F131218_george_w_bush_barack_obama_ap_60', 'http://static2.politico.com/dims4/default/28fb355/2147483647/resize/1160x%3E/quality/90/?url=http%3A%2F%2Fs3-origin-images.politico.com%2F2013%2F12%2F18%2F131218_george_w_bush_barack_obama_ap_60'],
             ['https://plus.google.com/+carlsenverlag/posts/2hibgWrmhp1', 'https://plus.google.com/+carlsenverlag/posts/2hibgWrmhp1'],
+            ['http://test.drupal.dd:8083/tests/localport.html', 'http://test.drupal.dd:8083/tests/localport.html'],
+            ['http://testuser@test.drupal.dd:8083/tests/identified.html', 'http://testuser@test.drupal.dd:8083/tests/identified.html'],
+            ['http://testuser:testpass@test.drupal.dd:8083/tests/authenticated.html', 'http://testuser:testpass@test.drupal.dd:8083/tests/authenticated.html'],
         ];
     }
 


### PR DESCRIPTION
The URL support - specifically  `\Embed\Url::buildUrl()` - doesn't include all parts of potential URLs. It's missing `port` number and `user:pass` parts.

I discovered this while writing some unit tests for a utility that was using this library, and tried to make some requests to itself - which was hosted on an internal sandboxed environment which ran the webserver on an alternate port.
Port is important, and though I don't have a use-case for user:pass support, we may as well support the URL syntax fully.

It looks like the same omission exists in `getAbsolute()`, but I don't have a test-case for that..
This fix was written with reference to http://php.net/manual/en/function.parse-url.php#106731 , that seems to be pretty accurate.