### PR TITLE
Provide AmCharts support.

### DIFF
--- a/src/Providers/OEmbed/Amcharts.php
+++ b/src/Providers/OEmbed/Amcharts.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+use Embed\Url;
+
+class Amcharts extends OEmbedImplementation
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getEndPoint(Url $url)
+    {
+        return 'https://live.amcharts.com/oembed';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getPatterns()
+    {
+        return ['https?://live.amcharts.com/*'];
+    }
+}


### PR DESCRIPTION
This should do it. However, AmCharts endpoint seems to have problems with escaped url query arguments. As a result https://live.amcharts.com/oembed/?url=http%253A%252F%252Flive.amcharts.com%252FczNjJ%252F&format=json won't work while https://live.amcharts.com/oembed/?url=http://live.amcharts.com/czNjJ/&format=json does. 

Example is from http://oembed.com/#section7. I emailed their support about the issue.