### PR TITLE
Make embed temporary cookies file name unique

### DIFF
--- a/src/RequestResolvers/Curl.php
+++ b/src/RequestResolvers/Curl.php
@@ -137,7 +137,7 @@ class Curl implements RequestResolverInterface
         $this->isBinary = null;
 
         if (!self::$tmpCookies) {
-            self::$tmpCookies = str_replace('//', '/', sys_get_temp_dir().'/embed-cookies.txt');
+            self::$tmpCookies = str_replace('//', '/', sys_get_temp_dir().'/embed-cookies.'.uniqid());
 
             if (is_file(self::$tmpCookies)) {
                 if (!is_writable(self::$tmpCookies)) {


### PR DESCRIPTION
We have a multiple applications sharing a server. Each application has their own user.
So if one embed request is made by app1, /tmp/embed-cookies.txt is owned by app1user, preventing other apps from working.

A better implementation would probably be to use [tempnam](http://php.net/manual/en/function.tempnam.php), but this should work well enough.