### PR TITLE
Fixed possible XSS attack

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -48,10 +48,10 @@ class Embed
         $error = $request->getError();
 
         if (empty($error)) {
-            throw new Exceptions\InvalidUrlException(sprintf("The url '%s' returns the http code %s", $request->getUrl(), $request->getHttpCode()));
+            throw new Exceptions\InvalidUrlException(sprintf("The url '%s' returns the http code %s", htmlentities($request->getUrl()), $request->getHttpCode()));
         }
 
-        throw new Exceptions\InvalidUrlException(sprintf("The url '%s' returns the following error: %s", $request->getUrl(), $error));
+        throw new Exceptions\InvalidUrlException(sprintf("The url '%s' returns the following error: %s", htmlentities($request->getUrl()), $error));
     }
 
     /**


### PR DESCRIPTION
https://oscarotero.com/embed2/demo/index.php?url=ftp://oscarotero.com/;<script>alert()</script>

The JS would be (obviously) blocked on modern browser because it clearly triggers XSS auditors but CSS/HTML isn't blocked and auditors can be bypassed. Added htmlentities() on the output message of error thrown.
