### PR TITLE
Added more feed types

### DIFF
--- a/src/Providers/Html.php
+++ b/src/Providers/Html.php
@@ -251,8 +251,11 @@ class Html extends Provider
 
                     case 'alternate':
                         switch ($link->getAttribute('type')) {
-                            case 'application/rss+xml':
                             case 'application/atom+xml':
+                            case 'application/rdf+xml':
+                            case 'application/rss+xml':
+                            case 'application/xml':
+                            case 'text/xml':
                                 $this->bag->add('feeds', $href);
                                 break;
                         }


### PR DESCRIPTION
Added more feed types.

Pretty common:
```html
<link rel="alternate" type="application/xml" href="https://example.com/feed/" />
<link rel="alternate" type="application/rdf+xml" href="https://example.com/feed/rdf/" />
```
Less common, but still used on a decent number of webpages:
```html
<link rel="alternate" type="text/xml" href="https://example.com/feed/" />
```