### PR TITLE
phpdoc: getProviders() return type fix

### DIFF
--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -146,7 +146,7 @@ abstract class Adapter implements DataInterface
     /**
      * Get all providers.
      *
-     * @return array
+     * @return DataInterface[]
      */
     public function getProviders()
     {

--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -146,7 +146,7 @@ abstract class Adapter implements DataInterface
     /**
      * Get all providers.
      *
-     * @return DataInterface[]
+     * @return Provider[]
      */
     public function getProviders()
     {


### PR DESCRIPTION
Fixed phpdoc return type for `getProviders()`.

Most PHP editors will no longer complain about unknown class/functions after this change...