### PR TITLE
Response constructor phpdoc + minor improvements

### DIFF
--- a/src/Http/AbstractResponse.php
+++ b/src/Http/AbstractResponse.php
@@ -18,7 +18,7 @@ abstract class AbstractResponse
     {
         $this->startingUrl = $startingUrl;
         $this->url = $url;
-        $this->statusCode = $statusCode;
+        $this->statusCode = (int)$statusCode;
         $this->contentType = $contentType;
         $this->headers = $headers;
         $this->info = $info;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -17,7 +17,18 @@ class Response extends AbstractResponse
     protected $jsonContent;
     protected $htmlContent;
 
-    public function __construct(Url $startingUrl, Url $url, $statusCode, $contentType, $content, array $headers, array $info)
+    /**
+	 * Response constructor.
+	 *
+	 * @param Url $startingUrl
+	 * @param Url $url
+	 * @param int $statusCode
+	 * @param string|null $contentType
+	 * @param string $content
+	 * @param array $headers
+	 * @param array $info
+	 */
+    public function __construct(Url $startingUrl, Url $url, $statusCode, $contentType, $content, array $headers, array $info = [])
     {
         parent::__construct($startingUrl, $url, $statusCode, $contentType, $headers, $info);
         $this->setContent($content);


### PR DESCRIPTION
Added phpdoc for Response constructor
_At least PHPStorm (probably others too) is guessing that `$content` is an array, witch it is not..._

Cast `$statusCode` as `int`
_This could saved me a lot of debugging, was receiving lots of `InvalidUrlException` for URLs with Status code == 200. Easy to fix internally, but sharing it upstream is probably an even better solution._

Added default value `[]` of array `$info` in the Response constructor.
_The value isn't used for anything internally, it's just there for optional external usage._