### PR TITLE
Repeat process only if alternative URL is valid

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -78,9 +78,11 @@ abstract class Embed
 
         if ($from !== $to && empty($info->code)) {
             
-            //except new result if valid
-            if($new_info = self::process(Url::create($info->url), $config, $dispatcher, TRUE)){
-                $info = $new_info;
+            //accept new result if valid
+            try {
+                return self::process(Url::create($info->url), $config, $dispatcher, TRUE);
+            } catch (\Exception $e) {
+                return $info;
             }
             
         }

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -80,7 +80,7 @@ abstract class Embed
             
             //accept new result if valid
             try {
-                return self::process(Url::create($info->url), $config, $dispatcher, TRUE);
+                return self::process(Url::create($info->url), $config, $dispatcher);
             } catch (\Exception $e) {
                 return $info;
             }
@@ -101,7 +101,7 @@ abstract class Embed
      *
      * @return Adapter
      */
-    private static function process(Url $url, array $config, DispatcherInterface $dispatcher, $no_exception=FALSE)
+    private static function process(Url $url, array $config, DispatcherInterface $dispatcher)
     {
         $response = $dispatcher->dispatch($url);
 
@@ -120,11 +120,6 @@ abstract class Embed
         //Use the default webpage adapter
         if (Adapters\Webpage::check($response)) {
             return new Adapters\Webpage($response, $config, $dispatcher);
-        }
-        
-        //Return false instead of throwing exception for second tries
-        if($no_exception){
-            return false;
         }
         
         if ($response->getError() === null) {


### PR DESCRIPTION
In some cases (e.g. slideshare that is private and allows access with secret link) the alternative URL is invalid. This small change makes Embed return the original $info when the second try fails. 