### PR TITLE
Update Pastebin adapter

### DIFF
--- a/src/Adapters/Pastebin.php
+++ b/src/Adapters/Pastebin.php
@@ -29,8 +29,8 @@ class Pastebin extends Webpage
         $this->height = null;
 
         $url = $this->getResponse()->getUrl();
-        $embed_url = 'http://pastebin.com/embed_iframe.php?i='.($url->getQueryParameter('i') ?: $url->getDirectoryPosition(0));
+        $path = '/embed_js' . $url->getPath();
 
-        return Utils::iframe($embed_url);
+        return Utils::script($this->getResponse()->getUrl()->getAbsolute($path));
     }
 }

--- a/tests/PastebinTest.php
+++ b/tests/PastebinTest.php
@@ -7,7 +7,7 @@ class PastebinTest extends AbstractTestCase
     public function testOne()
     {
         $this->assertEmbed(
-            'http://pastebin.com/d4biUtRm',
+            'https://pastebin.com/d4biUtRm',
             [
                 'title' => '[Bash] Pushing new git submodule to Heroku - Pastebin.com',
                 'type' => 'rich',


### PR DESCRIPTION
Pastebin has a new preferred method of embedding and is now HTTPS only.

> https://pastebin.com/embed/d4biUtRm