### PR TITLE
Option to stop following canonical url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Name | Type | Description
 -----|------|------------
 `min_image_width` | `int` | Minimal image width used to choose the main image
 `min_image_height` | `int` | Minimal image height used to choose the main image
+`choose_bigger_image` | `bool` | Choose the bigger image as the main image (instead the first found, that usually is the most relevant).
 `images_blacklist` | `string`&#124;`array` | Images that you don't want to be used. Could be plain text or [Uri](https://github.com/oscarotero/Embed/blob/master/src/Http/Url.php) match pattern.
 `url_blacklist` | `string`&#124;`array` | URLs that you don't want to be used. Could be plain text or [Uri](https://github.com/oscarotero/Embed/blob/master/src/Http/Url.php) match pattern.
-`choose_bigger_image` | `bool` | Choose the bigger image as the main image (instead the first found, that usually is the most relevant).
+`follow_canonical` | `bool` | Whether to redirect to the canonical URL or not.
 
 ## The providers
 
@@ -146,8 +147,10 @@ The options are passed as the second argument as you can see in the following ex
 $info = Embed::create($url, [
     'min_image_width' => 100,
     'min_image_height' => 100,
-    'images_blacklist' => 'example.com/*',
     'choose_bigger_image' => true,
+    'images_blacklist' => 'example.com/*',
+    'url_blacklist' => 'example.com/*',
+    'follow_canonical' => true,
 
     'html' => [
         'max_images' => 10,
@@ -211,7 +214,7 @@ class MyDispatcher implements DispatcherInterface
 }
 
 //Use the dispatcher passing as third argument
-$info = Embed::create('http://example.com', [], new MyDispatcher());
+$info = Embed::create('http://example.com', null, new MyDispatcher());
 ```
 
 The default curl dispatcher accepts the same options that the [curl_setopt PHP function](http://php.net/manual/en/function.curl-setopt.php). You can edit the default values:
@@ -232,7 +235,7 @@ $dispatcher = new CurlDispatcher([
     CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
 ]);
 
-$info = Embed::create('http://example.com', [], $dispatcher);
+$info = Embed::create('http://example.com', null, $dispatcher);
 ```
 
 ## Accessing to advanced data

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Used to get data directly from the html code of the page:
 Name | Type | Description
 -----|------|------------
 `max_images` | `int` | Max number of images fetched from the html code (searching for the `<img>` elements). By default is -1 (no limit). Use 0 to no get images.
-`external_images` | `bool|array` | By default is false, this means that images located in other domains are not allowed. You can set true (allow all) or provide an array of url patterns.
+`external_images` | `bool`&#124;`array` | By default is `false`, this means that images located in other domains are not allowed. You can set `true` (allow all) or provide an array of url patterns.
 
 ### google
 

--- a/demo/index.php
+++ b/demo/index.php
@@ -193,7 +193,7 @@ $adapterData = [
                 &nbsp;&nbsp;&nbsp;
                 <a href="https://github.com/oscarotero/Embed/">Get the source code from Github</a>
                 &nbsp;&nbsp; - &nbsp;&nbsp;
-                <a href="javascript:(function(){window.open('http://oscarotero.com/embed2/demo/index.php?url='+document.location)})();">or the bookmarklet</a>
+                <a href="javascript:(function(){window.open('http://oscarotero.com/embed3/demo/index.php?url='+document.location)})();">or the bookmarklet</a>
             </fieldset>
         </form>
 

--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -299,6 +299,11 @@ abstract class Adapter implements DataInterface
     public function getUrl()
     {
         $default = (string) $this->getResponse()->getUrl();
+
+        if (!$this->getConfig('follow_canonical')) {
+            return $default;
+        }
+
         $blacklist = $this->getConfig('url_blacklist');
 
         return $this->getFirstFromProviders(function (Provider $provider) use ($blacklist) {

--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -300,7 +300,7 @@ abstract class Adapter implements DataInterface
     {
         $default = (string) $this->getResponse()->getUrl();
 
-        if (!$this->getConfig('follow_canonical')) {
+        if ($this->getConfig('follow_canonical') === false) {
             return $default;
         }
 

--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -299,11 +299,6 @@ abstract class Adapter implements DataInterface
     public function getUrl()
     {
         $default = (string) $this->getResponse()->getUrl();
-
-        if ($this->getConfig('follow_canonical') === false) {
-            return $default;
-        }
-
         $blacklist = $this->getConfig('url_blacklist');
 
         return $this->getFirstFromProviders(function (Provider $provider) use ($blacklist) {

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -15,6 +15,7 @@ abstract class Embed
     public static $default_config = [
         'min_image_width' => 1,
         'min_image_height' => 1,
+        'choose_bigger_image' => false,
         'images_blacklist' => [],
         'url_blacklist' => [
             '?&ns_campaign=*',
@@ -23,7 +24,7 @@ abstract class Embed
             '?&utm_medium=*',
             '?&utm_source=*',
         ],
-        'choose_bigger_image' => false,
+        'follow_canonical' => true,
 
         'html' => [
             'max_images' => -1,

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -71,19 +71,20 @@ abstract class Embed
 
         $info = self::process($url, $config, $dispatcher);
 
-        // Repeat the process if:
-        // - The canonical url is different
-        // - No embed code has found
-        $from = preg_replace('|^(\w+://)|', '', rtrim((string) $info->getResponse()->getUrl(), '/'));
-        $to = preg_replace('|^(\w+://)|', '', rtrim($info->url, '/'));
+        if ($info->getConfig('follow_canonical') !== false) {
+            // Repeat the process if:
+            // - The canonical url is different
+            // - No embed code has found
+            $from = preg_replace('|^(\w+://)|', '', rtrim((string)$info->getResponse()->getUrl(), '/'));
+            $to = preg_replace('|^(\w+://)|', '', rtrim($info->url, '/'));
 
-        if ($from !== $to && empty($info->code)) {
-            
-            //accept new result if valid
-            try {
-                return self::process(Url::create($info->url), $config, $dispatcher);
-            } catch (\Exception $e) {
-                return $info;
+            if ($from !== $to && empty($info->code)) {
+                //accept new result if valid
+                try {
+                    return self::process(Url::create($info->url), $config, $dispatcher);
+                } catch (\Exception $e) {
+                    return $info;
+                }
             }
         }
 

--- a/tests/RedirectionsTest.php
+++ b/tests/RedirectionsTest.php
@@ -6,6 +6,25 @@ use Embed\Embed;
 
 class RedirectionsTest extends AbstractTestCase
 {
+    public function testGenericCanonical()
+    {
+        $config = Embed::$default_config;
+
+        $expected = 'https://www.dagbladet.no/emne/utenriks';
+        $unwanted = 'http://www.dagbladet.no';
+
+        // Do NOT follow canonical
+        $config['follow_canonical'] = false;
+        $info1 = Embed::create($expected, $config);
+        $this->assertString($expected, $info1->url);
+
+        // Follow canonical
+        // If this test fails, the unwanted canonical url has changed
+        $config['follow_canonical'] = true;
+        $info2 = Embed::create($expected, $config);
+        $this->assertString($unwanted, $info2->url);
+    }
+
     public function testGoogleTranslate()
     {
         $info1 = Embed::create('https://translate.google.com/translate?sl=de&tl=en&js=y&prev=_t&hl=en&ie=UTF-8&u=http%3A%2F%2Fwww.heise.de%2Fnewsticker%2Fmeldung%2FXKeyscore-Quellcode-Tor-Nutzer-werden-von-der-NSA-als-Extremisten-markiert-und-ueberwacht-2248328.html&edit-text=');

--- a/tests/RedirectionsTest.php
+++ b/tests/RedirectionsTest.php
@@ -16,13 +16,13 @@ class RedirectionsTest extends AbstractTestCase
         // Do NOT follow canonical
         $config['follow_canonical'] = false;
         $info1 = Embed::create($expected, $config);
-        $this->assertString($expected, $info1->url);
+        $this->assertString($expected, $info1->getResponse()->getUrl());
 
         // Follow canonical
         // If this test fails, the unwanted canonical url has changed
         $config['follow_canonical'] = true;
         $info2 = Embed::create($expected, $config);
-        $this->assertString($unwanted, $info2->url);
+        $this->assertString($unwanted, $info2->getResponse()->getUrl());
     }
 
     public function testGoogleTranslate()

--- a/tests/RedirectionsTest.php
+++ b/tests/RedirectionsTest.php
@@ -8,20 +8,16 @@ class RedirectionsTest extends AbstractTestCase
 {
     public function testGenericCanonical()
     {
-        $config = Embed::$default_config;
-
         $expected = 'https://www.dagbladet.no/emne/utenriks';
-        $unwanted = 'http://www.dagbladet.no';
+        $unwanted = 'http://www.dagbladet.no/';
 
         // Do NOT follow canonical
-        $config['follow_canonical'] = false;
-        $info1 = Embed::create($expected, $config);
+        $info1 = Embed::create($expected, ['follow_canonical' => false]);
         $this->assertString($expected, $info1->getResponse()->getUrl());
 
         // Follow canonical
         // If this test fails, the unwanted canonical url has changed
-        $config['follow_canonical'] = true;
-        $info2 = Embed::create($expected, $config);
+        $info2 = Embed::create($expected, ['follow_canonical' => true]);
         $this->assertString($unwanted, $info2->getResponse()->getUrl());
     }
 


### PR DESCRIPTION
Alternative fix for #232 

An simple on/off switch.
Either you follow/redirect to the canonical url (when discovered), or you simply doesn't.

Simply put `follow_canonical` (`bool`) in your config array. Default value: `true`