### PR TITLE
Add Dailymotion provider

### DIFF
--- a/src/Providers/OEmbed/Dailymotion.php
+++ b/src/Providers/OEmbed/Dailymotion.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+class Dailymotion extends EndPoint implements EndPointInterface
+{
+    protected static $pattern = '*dailymotion.*';
+    protected static $endPoint = 'http://www.dailymotion.com/services/oembed';
+}

--- a/tests/DailyMotionTest.php
+++ b/tests/DailyMotionTest.php
@@ -17,6 +17,7 @@ class DailyMotionTest extends AbstractTestCase
                 'imageHeight' => 240,
                 'providerName' => 'Dailymotion',
                 'providerUrl' => 'http://www.dailymotion.com',
+                'code' => '<iframe frameborder="0" width="480" height="360" src="http://www.dailymotion.com/embed/video/xy0wd" allowfullscreen></iframe>'
             ]
         );
     }


### PR DESCRIPTION
This pull request add the dailymotion oembed endpoint to address dailymotion.

Before this PR, the OEmbed provider didn't make any call to the OEmbed endpoint of dailymotion. Thus, I experienced some problems with the downloaded player (i.e. the `maxwidth` wasn't applyed). 

I hope this should fix the problem.

Note 1: some tests didn't passe, but as this was not linked to dailymotion, I didn't pay attention to them.

Note 2: If I have to improve this PR, or if you can suggest something, do not hesitate.