### PR TITLE
Added a Twitter oembed provider to use the publish.twitter.com subdomain

### DIFF
--- a/src/Providers/OEmbed/Twitter.php
+++ b/src/Providers/OEmbed/Twitter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+use Embed\Url;
+
+class Twitter extends OEmbedImplementation
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getEndPoint(Url $url)
+    {
+        return 'https://publish.twitter.com/oembed';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getPatterns()
+    {
+      return ['https?://*.twitter.com/*'];
+    }
+}


### PR DESCRIPTION
Fix for #273 

As mentioned there, this is against 2.x where I tested it.

Looks like they should be properties for master/3.x