### PR TITLE
Tumblr provider

### DIFF
--- a/src/Providers/OEmbed/Tumblr.php
+++ b/src/Providers/OEmbed/Tumblr.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+use Embed\Adapters\Adapter;
+use Embed\Http\Response;
+use Embed\Http\Url;
+
+class Tumblr extends EndPoint implements EndPointInterface
+{
+    protected static $pattern = [
+        '*.tumblr.com/post/*'
+    ];
+
+    protected static $endPoint = 'https://www.tumblr.com/oembed/1.0';
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(Adapter $adapter)
+    {
+        $response = $adapter->getResponse();
+        if ($response->getStartingUrl()->match(static::$pattern)) {
+            return new static($response);
+        }
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param Response $response
+     */
+    private function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndPoint()
+    {
+        return Url::create(static::$endPoint)
+                ->withQueryParameters([
+                    'url' => (string) $this->response->getStartingUrl()
+                ]);
+    }
+}

--- a/tests/TumblrTest.php
+++ b/tests/TumblrTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Embed\Tests;
+
+class TumblrTest extends AbstractTestCase
+{
+    public function testOne()
+    {
+        $this->assertEmbed(
+            'http://he-who-photographs-rather-ok.tumblr.com/post/165326273724',
+            [
+                'url' => 'http://he-who-photographs-rather-ok.tumblr.com/post/165326273724',
+                'authorName' => 'He-who-photographs-rather-OK',
+                'authorUrl' => 'http://he-who-photographs-rather-ok.tumblr.com/',
+                'type' => 'rich',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
In Endpoint.php matching is made against `$response->getUrl()` (`https://www.tumblr.com/privacy/consent?redirect=...`)
so I had to override it in order to match against `$response->getStartingUrl()`
