### PR TITLE
Correctly detect QuickTime videos as video

### DIFF
--- a/src/Adapters/File.php
+++ b/src/Adapters/File.php
@@ -13,6 +13,7 @@ class File extends Adapter
 {
     private static $contentTypes = [
         'video/ogg' => ['video', 'videoHtml'],
+        'video/quicktime' => ['video', 'videoHtml'],
         'application/ogg' => ['video', 'videoHtml'],
         'video/ogv' => ['video', 'videoHtml'],
         'video/webm' => ['video', 'videoHtml'],


### PR DESCRIPTION
This pull request adds support for correctly detecting files with `video/quicktime` as the content type as a `video` instead of `file` type.