### PR TITLE
Fixed protocols (HTTP to HTTPS)

### DIFF
--- a/src/Providers/OEmbed/Instagram.php
+++ b/src/Providers/OEmbed/Instagram.php
@@ -10,7 +10,7 @@ class Instagram extends EndPoint implements EndPointInterface
         'instagram.com/p/*',
         'www.instagram.com/p/*',
     ];
-    protected static $endPoint = 'http://api.instagram.com/oembed';
+    protected static $endPoint = 'https://api.instagram.com/oembed';
 
     /**
      * {@inheritdoc}

--- a/src/Providers/OEmbed/Soundcloud.php
+++ b/src/Providers/OEmbed/Soundcloud.php
@@ -5,5 +5,5 @@ namespace Embed\Providers\OEmbed;
 class Soundcloud extends EndPoint implements EndPointInterface
 {
     protected static $pattern = 'soundcloud.com/*';
-    protected static $endPoint = 'http://soundcloud.com/oembed';
+    protected static $endPoint = 'https://soundcloud.com/oembed';
 }


### PR DESCRIPTION
I've changed the endpoints for the providers "Instagram" and "Soundcloud" due to the fact that the were configured with HTTP instead of HTTPS. We've to take care that this could be a breaking change on a infrastructure level due missing port unlocks.