### PR TITLE
Enforced type of suffixes to array

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -9,7 +9,7 @@ class Url
 {
     private $info;
     private $url;
-    private static $public_suffix_list;
+    private static $public_suffix_list = [];
 
     /**
      * Create a new Url instance.
@@ -223,7 +223,7 @@ class Url
                 $tld = $host[1].'.'.$host[0];
                 $suffixes = self::getSuffixes();
 
-                if (in_array($tld, (array)$suffixes, true)) {
+                if (in_array($tld, $suffixes, true)) {
                     return $first_level ? $host[2].'.'.$tld : $host[2];
                 }
 
@@ -619,8 +619,13 @@ class Url
 
     private static function getSuffixes()
     {
-        if (self::$public_suffix_list === null) {
-            self::$public_suffix_list = include __DIR__.'/../resources/public_suffix_list.php';
+    	
+        if (count(self::$public_suffix_list) === 0) {
+        	$suffixes = @include __DIR__.'/../resources/public_suffix_list.php';
+
+        	if (is_array($suffixes)) {
+		        self::$public_suffix_list = $suffixes;
+	        }
         }
 
         return self::$public_suffix_list;

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -223,7 +223,7 @@ class Url
                 $tld = $host[1].'.'.$host[0];
                 $suffixes = self::getSuffixes();
 
-                if (in_array($tld, $suffixes, true)) {
+                if (in_array($tld, (array)$suffixes, true)) {
                     return $first_level ? $host[2].'.'.$tld : $host[2];
                 }
 

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -9,7 +9,7 @@ class Url
 {
     private $info;
     private $url;
-    private static $public_suffix_list = [];
+    private static $public_suffix_list;
 
     /**
      * Create a new Url instance.
@@ -619,15 +619,9 @@ class Url
 
     private static function getSuffixes()
     {
-    	
-        if (count(self::$public_suffix_list) === 0) {
-        	$suffixes = @include __DIR__.'/../resources/public_suffix_list.php';
-
-        	if (is_array($suffixes)) {
-		        self::$public_suffix_list = $suffixes;
-	        }
-        }
-
+        if (self::$public_suffix_list === null) {
+            self::$public_suffix_list = (array) include __DIR__.'/../resources/public_suffix_list.php';
+    	}
         return self::$public_suffix_list;
     }
 


### PR DESCRIPTION
When the runtime including of the suffixes (`self::$public_suffix_list = include __DIR__.'/../resources/public_suffix_list.php';`) list don't work out the method return value is a boolean. So the in_array method will throw an error. Why this is implemented as a include instead of a private property or constant value?