### PR TITLE
Updated include of public suffixes

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -620,7 +620,7 @@ class Url
     private static function getSuffixes()
     {
         if (self::$public_suffix_list === null) {
-            self::$public_suffix_list = (array) include __DIR__.'/../resources/public_suffix_list.php';
+            self::$public_suffix_list = (@include __DIR__.'/../resources/public_suffix_list.php') ? [];
     	}
         return self::$public_suffix_list;
     }


### PR DESCRIPTION
I've encountered another problem. When you have restricted your include paths via your php.ini your're getting a warning when you using this library. To solve this I've added the @ operator and enforced the return value of this include to be an array. 