### PR TITLE
Better space encoding in Url

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -599,17 +599,17 @@ class Url
             $path = substr($path, 0, -strlen($file));
 
             if (preg_match('/(.*)\.([\w]+)$/', $file, $match)) {
-                $this->info['file'] = urldecode($match[1]);
+                $this->info['file'] = rawurldecode($match[1]);
                 $this->info['extension'] = $match[2];
             } else {
-                $this->info['file'] = urldecode($file);
+                $this->info['file'] = rawurldecode($file);
             }
         }
 
         $this->info['path'] = [];
 
         foreach (explode('/', $path) as $dir) {
-            $dir = urldecode($dir);
+            $dir = rawurldecode($dir);
 
             if ($dir !== '') {
                 $this->info['path'][] = $dir;
@@ -622,7 +622,7 @@ class Url
         if (self::$public_suffix_list === null) {
             self::$public_suffix_list = (@include __DIR__.'/../resources/public_suffix_list.php') ?: [];
         }
-      
+
         return self::$public_suffix_list;
     }
 
@@ -639,7 +639,7 @@ class Url
         $enc_url = preg_replace_callback(
             '%[^:/@?&=#]+%usD',
             function ($matches) {
-                return urlencode($matches[0]);
+                return rawurlencode($matches[0]);
             },
             $url
         );
@@ -655,9 +655,8 @@ class Url
         }
 
         foreach ($parts as $name => $value) {
-            $parts[$name] = urldecode($value);
+            $parts[$name] = rawurldecode($value);
         }
-
         return $parts;
     }
 
@@ -665,7 +664,7 @@ class Url
     {
         // : - used for files
         // @ and , - used for GoogleMaps adapter url (in view and streetview modes)
-        return str_replace(['%3A','%40','%2C'], [':','@',','], urlencode($path));
+        return str_replace(['%3A','%40','%2C'], [':','@',','], rawurlencode($path));
     }
 
     private static function validUrlOrEmpty($url)

--- a/tests/CatizzTest.php
+++ b/tests/CatizzTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Embed\Tests;
+
+class CatizzTest extends AbstractTestCase
+{
+    public function testSimple()
+    {
+        $this->assertEmbed(
+            'https://www.catizz.com/medias/common/chat-savannah.jpg',
+            [
+                'url' => 'https://www.catizz.com/medias/common/chat-savannah.jpg',
+                'code' => '<img src="https://www.catizz.com/medias/common/chat-savannah.jpg" alt="Remote file" width="1633" height="1164">',
+                'imageWidth' => 1633,
+                'imageHeight' => 1164,
+                'providerName' => 'catizz',
+            ]
+        );
+    }
+
+    public function testWithSpaces()
+    {
+        $urls = [
+            'https://www.catizz.com/medias/common/miaulement chat .jpg',
+            'https://www.catizz.com/medias/common/miaulement%20chat%20.jpg',
+        ];
+
+        foreach ($urls as $url) {
+            $this->assertEmbed(
+                $url,
+                [
+                    'url' => 'https://www.catizz.com/medias/common/miaulement%20chat%20.jpg',
+                    'code' => '<img src="https://www.catizz.com/medias/common/miaulement%20chat%20.jpg" alt="Remote file" width="1688" height="1125">',
+                    'imageWidth' => 1688,
+                    'imageHeight' => 1125,
+                    'providerName' => 'catizz',
+                ]
+            );
+        }
+    }
+
+    public function testWithSpaceAndBraces()
+    {
+        $urls = [
+            'https://www.catizz.com/medias/common/accessoires-chat-canva (1).jpg',
+            'https://www.catizz.com/medias/common/accessoires-chat-canva%20(1).jpg',
+            'https://www.catizz.com/medias/common/accessoires-chat-canva %281).jpg',
+            'https://www.catizz.com/medias/common/accessoires-chat-canva%20%281%29.jpg',
+        ];
+
+        foreach ($urls as $url) {
+            $this->assertEmbed(
+                $url,
+                [
+                    'url' => 'https://www.catizz.com/medias/common/accessoires-chat-canva%20%281%29.jpg',
+                    'code' => '<img src="https://www.catizz.com/medias/common/accessoires-chat-canva%20%281%29.jpg" alt="Remote file" width="600" height="338">',
+                    'imageWidth' => 600,
+                    'imageHeight' => 338,
+                    'providerName' => 'catizz',
+                ]
+            );
+        }
+    }
+}

--- a/tests/GoogleTest.php
+++ b/tests/GoogleTest.php
@@ -36,7 +36,7 @@ class GoogleTest extends AbstractTestCase
             [
                 'title' => 'Grow your business through email marketing Learn more here: http://bit.ly/Yr...',
                 'type' => 'rich',
-                'code' => '<script src="https://apis.google.com/js/plusone.js" type="text/javascript"></script><div class="g-post" data-href="https://plus.google.com/+StephanHovnanian/posts/6apV9FHgo4k"></div>',
+                'code' => '<script src="https://apis.google.com/js/plusone.js" type="text/javascript"></script><div class="g-post" data-href="https://plus.google.com/%2BStephanHovnanian/posts/6apV9FHgo4k"></div>',
                 'providerName' => 'Google Plus',
             ]
         );

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -18,7 +18,7 @@ class UrlTest extends AbstractTestCase
             ['https://www.tumblr.com/oembed//1.0//', 'https://www.tumblr.com/oembed/1.0/'],
             ['https://animoto.com/oembeds/create.xml?automated=true&options=start_hq', 'https://animoto.com/oembeds/create.xml?automated=true&options=start_hq'],
             ['http://static2.politico.com/dims4/default/28fb355/2147483647/resize/1160x%3E/quality/90/?url=http%3A%2F%2Fs3-origin-images.politico.com%2F2013%2F12%2F18%2F131218_george_w_bush_barack_obama_ap_60', 'http://static2.politico.com/dims4/default/28fb355/2147483647/resize/1160x%3E/quality/90/?url=http%3A%2F%2Fs3-origin-images.politico.com%2F2013%2F12%2F18%2F131218_george_w_bush_barack_obama_ap_60'],
-            ['https://plus.google.com/+carlsenverlag/posts/2hibgWrmhp1', 'https://plus.google.com/+carlsenverlag/posts/2hibgWrmhp1'],
+            ['https://plus.google.com/+carlsenverlag/posts/2hibgWrmhp1', 'https://plus.google.com/%2Bcarlsenverlag/posts/2hibgWrmhp1'],
             ['http://test.drupal.dd:8083/tests/localport.html', 'http://test.drupal.dd:8083/tests/localport.html'],
             ['http://testuser@test.drupal.dd:8083/tests/identified.html', 'http://testuser@test.drupal.dd:8083/tests/identified.html'],
             ['http://testuser:testpass@test.drupal.dd:8083/tests/authenticated.html', 'http://testuser:testpass@test.drupal.dd:8083/tests/authenticated.html'],
@@ -27,6 +27,7 @@ class UrlTest extends AbstractTestCase
             ['https://pbs.twimg.com/media/CvCZ90BXYAE5q80.png:large', 'https://pbs.twimg.com/media/CvCZ90BXYAE5q80.png:large'],
             ['http://img.bibo.kz/?7142389.jpg', 'http://img.bibo.kz/?7142389.jpg'],
             ['https://twitter.com/search?q=google%2B&src=typd&lang=en', 'https://twitter.com/search?q=google%2B&src=typd&lang=en'],
+            ['https://www.catizz.com/medias/common/accessoires-chat-canva (1).jpg', 'https://www.catizz.com/medias/common/accessoires-chat-canva%20%281%29.jpg'],
         ];
     }
 


### PR DESCRIPTION
Closes #255 
Replaces https://github.com/oscarotero/Embed/pull/259 that was incomplete (Google Plus)

The problem with GooglePlus was due to the `+` no being encoded into `%2B`
This Pull Request fix this.

However, I still have an issue with the title in some test, I'll may need some help to fix that.

```
1) Embed\Tests\GoogleTest::testMap
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-Tordoia, A Coruña
+Tordoia,+A+Coruña
```

The title will have to be reviewed (transform + into space).