### PR TITLE
Add Vimeo as a provider

### DIFF
--- a/src/Adapters/Vimeo.php
+++ b/src/Adapters/Vimeo.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Embed\Adapters;
+
+use Embed\Http\Response;
+
+/**
+ * Adapter to provide information from Vimeo.
+ * Required when Vimeo returns a 403 status code.
+ */
+class Vimeo extends Webpage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function check(Response $response)
+    {
+        return $response->isValid([200, 403]) && $response->getUrl()->match([
+            'vimeo.com/*',
+        ]);
+    }
+}

--- a/src/Providers/OEmbed/Vimeo.php
+++ b/src/Providers/OEmbed/Vimeo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+class Vimeo extends EndPoint implements EndPointInterface
+{
+    protected static $pattern = ['vimeo.com/*'];
+    protected static $endPoint = 'https://vimeo.com/api/oembed.json';
+}

--- a/tests/VimeoTest.php
+++ b/tests/VimeoTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Embed\Tests;
+
+class VimeoTest extends AbstractTestCase
+{
+    public function testOne()
+    {
+        $this->assertEmbed(
+            'https://vimeo.com/235352744',
+            [
+                'title' => 'Vimeo Live is here',
+                'providerName' => 'Vimeo',
+                'width' => 640,
+                'height' => 360,
+                'code' => '<iframe src="https://player.vimeo.com/video/235352744?app_id=122963" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen title="Vimeo Live is here"></iframe>',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Fixes #326.

Add Vimeo as a provider so as to take advantage of the oEmbed endpoint.

Vimeo has started to ban IP blocks from popular providers  (DigitalOcean, Vultr, Google Cloud) due to malicious behaviour from some IPs but subsequently affecting legitimate use cases. The ban results in 403 error codes when attempting to embed URLs using the standard "webpage" adapter, however oEmbed is unaffected.