### PR TITLE
Added an Adapter and OEmbed provider for Vimeo urls.

### DIFF
--- a/src/Adapters/Vimeo.php
+++ b/src/Adapters/Vimeo.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Embed\Adapters;
+
+use Embed\Request;
+use Embed\Providers;
+
+/**
+ * Adapter to provide information from Vimeo.
+ * Required when Vimeo returns a 403 status code.
+ */
+class Vimeo extends Webpage implements AdapterInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function check(Request $request)
+    {
+        return $request->isValid([200, 403]) && $request->match([
+            'https?://*.vimeo.com*',
+            'https?://vimeo.com*',
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function run()
+    {
+        if ($this->request->getHttpCode() === 403) {
+            $this->addProvider('oembed', new Providers\OEmbed());
+
+         return;
+        }
+
+        parent::run();
+    }
+
+}

--- a/src/Providers/OEmbed/Vimeo.php
+++ b/src/Providers/OEmbed/Vimeo.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+use Embed\Url;
+
+class Vimeo extends OEmbedImplementation
+{
+
+    /**
+     * @inheritDoc
+     */
+    public static function getEndPoint(Url $url)
+    {
+        return 'https://vimeo.com/api/oembed.json';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getPatterns()
+    {
+        return [
+            'https?://*.vimeo.com*',
+            'https?://vimeo.com*',
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getParams(Url $url)
+    {
+        return [
+            'url' => $url->withScheme('http')->getUrl(),
+        ];
+    }
+}


### PR DESCRIPTION
Version 2.x doesn't have dedicated support for embedding Vimeo urls. This sometimes causes issues with particular Cloud hosting providers, like said in https://github.com/oscarotero/Embed/issues/326#issuecomment-531739948 and fixed for v3.x in https://github.com/oscarotero/Embed/pull/328.

This PR adds the same functionality for v2.x. Which is necessary as it's used in a popular Drupal module: https://www.drupal.org/project/url_embed.

**Vimeo developer documentation:**
- https://developer.vimeo.com/api/oembed/videos