### PR TITLE
Fixed PHP DOM extension is not specified as requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "ext-curl": "*",
+        "ext-dom": "*",
         "ext-mbstring": "*",
         "composer/ca-bundle": "^1.0"
     },


### PR DESCRIPTION
Problem
* The DOM extension is required, but not specified as required.

Details
* Some lightweight Linux distributions of PHP do not have all extensions installed by default (e.g. Docker images optimized for speed/size).