### PR TITLE
make oembed configurable for additional oembed parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to send settings to `CurlClient`. Added the `cookies_path` setting to customize the file used for cookies. #345
 - `Document::selectCss()` function to select elements using css selectors instead xpath (it requires symfony/css-selector)
 - `Document::removeCss()` function to remove elements using css selectors instead xpath (it requires symfony/css-selector)
+- Ability to configure OEmbed parameters from the outside
 
 ## 4.0.0 - 2020-03-13
 Full library refactoring.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ $oembed->int('width'); //Return the value as integer
 $oembed->url('url'); //Return the value as full url (converts relative urls to absolutes)
 ```
 
+Additional oEmbed parameters (like instagrams `hidecaption`) can also be provided:
+```php
+$embed = new Embed();
+
+$result = $embed->get('https://www.instagram.com/p/B_C0wheCa4V/');
+$result->setSettings([
+    'oembed:query_parameters' => ['hidecaption' => true]
+]);
+$oembed = $info->getOEmbed();
+```
+
 ## LinkedData
 
 Another API available by default, used to extract info using the [JsonLD](https://www.w3.org/TR/json-ld/) schema.
@@ -247,7 +258,7 @@ The `Extractor` class has many `Detectors`. Each detector is responsible to dete
 
 So, an adapter is basically an extractor created specifically for a site. It can contains also custom detectors or apis. If you see the `src/Adapters` folder you can see all adapters.
 
-If you create an adapter, you need also register to Embed, so it knows in which website needs to use. To do that, there's the `ExtractorFactory` object, that is responsible for instantiate the right extractor for each site. 
+If you create an adapter, you need also register to Embed, so it knows in which website needs to use. To do that, there's the `ExtractorFactory` object, that is responsible for instantiate the right extractor for each site.
 
 ```php
 use Embed\Embed;

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -129,7 +129,7 @@ class Extractor
         return $this->settings;
     }
 
-    public function getSetting(string $key): ?string
+    public function getSetting(string $key)
     {
         return $this->settings[$key] ?? null;
     }

--- a/src/OEmbed.php
+++ b/src/OEmbed.php
@@ -22,6 +22,13 @@ class OEmbed
         return self::$providers;
     }
 
+    public function getOembedQueryParameters(string $url): array
+    {
+        $queryParameters = ['url' => $url, 'format' => 'json'];
+
+        return array_merge($queryParameters, $this->extractor->getSetting('oembed:query_parameters') ?? []);
+    }
+
     protected function fetchData(): array
     {
         $this->endpoint = $this->detectEndpoint();
@@ -63,7 +70,7 @@ class OEmbed
 
         return $this->extractor->getCrawler()
             ->createUri($endpoint)
-            ->withQuery(http_build_query(['url' => $url, 'format' => 'json']));
+            ->withQuery(http_build_query($this->getOembedQueryParameters($url)));
     }
 
     private static function searchEndpoint(array $providers, string $url): ?string


### PR DESCRIPTION
Many OEmbed providers allow additional query parameters on their oembed services.
So on e.g.  instagram there is a parameter for hiding the caption.

`hidecaption` 

With this PR it is easy to configure that option from the outside:
```
        $embed = new Embed();

        $result = $embed->get('https://www.instagram.com/p/B_C0wheCa4V/');
        $result->getOEmbed()->setQueryParameters(['hidecaption' => true]);
        $code = $result->code;
```