### PR TITLE
Add OEmbed Provider for TikTok.

### DIFF
--- a/src/Providers/OEmbed/TIkTok.php
+++ b/src/Providers/OEmbed/TIkTok.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+use Embed\Http\Url;
+
+class TikTok extends EndPoint implements EndPointInterface
+{
+    protected static $pattern = [
+    	'*.tiktok.com/*'
+    ];
+
+    protected static $endPoint = 'https://www.tiktok.com/oembed';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getEndPoint()
+	{
+		return Url::create(static::$endPoint)
+			->withQueryParameters([
+				'url' => (string) $this->response->getStartingUrl(),
+				'format' => 'json',
+			]);
+	}
+}


### PR DESCRIPTION
The OEmbed plugin from wrav/oembed uses the embed/embed repository as a dependency. To add TikTok support for this plugin I've added the TikTok oembed provider.