### PR TITLE
(v3) Mixcloud OEmbed Provider

### DIFF
--- a/src/Providers/OEmbed/Mixcloud.php
+++ b/src/Providers/OEmbed/Mixcloud.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Embed\Providers\OEmbed;
+
+class Mixcloud extends EndPoint implements EndPointInterface
+{
+    protected static $pattern = 'www.mixcloud.com/*/';
+    protected static $endPoint = 'https://www.mixcloud.com/oembed/';
+}

--- a/tests/MixcloudTest.php
+++ b/tests/MixcloudTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Embed\Tests;
+
+class MixcloudTest extends AbstractTestCase
+{
+    public function testOne()
+    {
+        $this->assertEmbed(
+            'https://www.mixcloud.com/malka11/malka-pres-lockdown-sessions-anjuna-history-2010-2020-/',
+            [
+                'title' => 'Malka Pres. #Lockdown Sessions - Anjuna History 2000-2010',
+                'image' => 'https://thumbnailer.mixcloud.com/unsafe/600x600/extaudio/1/4/9/b/ea7f-32ca-4f49-9559-60eada3867e5',
+                'authorName' => 'Malka',
+                'authorUrl' => 'https://www.mixcloud.com/malka11/',
+                'type' => 'rich',
+                'providerName' => 'Mixcloud',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Resolves #361

Added a test as well:

![Screen Shot 2020-06-06 at 11 39 40](https://user-images.githubusercontent.com/1840284/83941319-a58eb380-a7ea-11ea-8204-1fbe9f139ad4.png)

(although other tests for other providers will make the whole test suite not pass because of unreachable urls and outdated apis)
