### PR TITLE
Add twitter adapter to prevent errors on 429 status code

### DIFF
--- a/src/Adapters/Twitter.php
+++ b/src/Adapters/Twitter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Embed\Adapters;
+
+use Embed\Http\Response;
+
+/**
+ * Adapter to provide information from twitter.
+ * Required when twitter returns a 429 status code.
+ */
+class Twitter extends Webpage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function check(Response $response)
+    {
+        return $response->isValid([200, 429]) && $response->getUrl()->match([
+            '*twitter.*',
+        ]);
+    }
+}


### PR DESCRIPTION
Twitter embed wasn't working anymore for me. Every request we did was a 429, which threw an exception. With this adapter the 429 shouldn't throw an exception anymore and should work as expected. Tested this already on multiple environments, because clients really depend on this.

**Issue**
https://github.com/oscarotero/Embed/issues/337

**Changelog:**
* Add Twitter adapter to prevent errors on 429 status code