### PR TITLE
Rename match function for PHP 8 compatibility

### DIFF
--- a/src/Adapters/Archive/Detectors/Code.php
+++ b/src/Adapters/Archive/Detectors/Code.php
@@ -6,7 +6,7 @@ namespace Embed\Adapters\Archive\Detectors;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -15,7 +15,7 @@ class Code extends Detector
         $uri = $this->extractor->getUri();
         $path = $uri->getPath();
 
-        if (!match('/details/*', $path)) {
+        if (!matchPath('/details/*', $path)) {
             return null;
         }
 

--- a/src/Adapters/CadenaSer/Detectors/Code.php
+++ b/src/Adapters/CadenaSer/Detectors/Code.php
@@ -7,7 +7,7 @@ use function Embed\cleanPath;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -21,7 +21,7 @@ class Code extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/audio/*', $uri->getPath())) {
+        if (!matchPath('/audio/*', $uri->getPath())) {
             return null;
         }
 

--- a/src/Adapters/Flickr/Detectors/Code.php
+++ b/src/Adapters/Flickr/Detectors/Code.php
@@ -7,7 +7,7 @@ use function Embed\cleanPath;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -21,7 +21,7 @@ class Code extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/photos/*', $uri->getPath())) {
+        if (!matchPath('/photos/*', $uri->getPath())) {
             return null;
         }
 

--- a/src/Adapters/Github/Detectors/Code.php
+++ b/src/Adapters/Github/Detectors/Code.php
@@ -6,7 +6,7 @@ namespace Embed\Adapters\Github\Detectors;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -21,7 +21,7 @@ class Code extends Detector
         $uri = $this->extractor->getUri();
         $path = $uri->getPath();
 
-        if (!match('/*/*/blob/*', $path)) {
+        if (!matchPath('/*/*/blob/*', $path)) {
             return null;
         }
 

--- a/src/Adapters/ImageShack/Api.php
+++ b/src/Adapters/ImageShack/Api.php
@@ -5,7 +5,7 @@ namespace Embed\Adapters\ImageShack;
 
 use function Embed\getDirectory;
 use Embed\HttpApiTrait;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Api
 {
@@ -15,10 +15,10 @@ class Api
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/i/*', $uri->getPath())) {
+        if (!matchPath('/i/*', $uri->getPath())) {
             $uri = $this->extractor->getRequest()->getUri();
 
-            if (!match('/i/*', $uri->getPath())) {
+            if (!matchPath('/i/*', $uri->getPath())) {
                 return [];
             }
         }

--- a/src/Adapters/Pinterest/Detectors/Code.php
+++ b/src/Adapters/Pinterest/Detectors/Code.php
@@ -6,7 +6,7 @@ namespace Embed\Adapters\Pinterest\Detectors;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -20,7 +20,7 @@ class Code extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/pin/*', $uri->getPath())) {
+        if (!matchPath('/pin/*', $uri->getPath())) {
             return null;
         }
 

--- a/src/Adapters/Sassmeister/Detectors/Code.php
+++ b/src/Adapters/Sassmeister/Detectors/Code.php
@@ -6,7 +6,7 @@ namespace Embed\Adapters\Sassmeister\Detectors;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -20,7 +20,7 @@ class Code extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/gist/*', $uri->getPath())) {
+        if (!matchPath('/gist/*', $uri->getPath())) {
             return null;
         }
 

--- a/src/Adapters/Snipplr/Detectors/Code.php
+++ b/src/Adapters/Snipplr/Detectors/Code.php
@@ -6,7 +6,7 @@ namespace Embed\Adapters\Snipplr\Detectors;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Code extends Detector
 {
@@ -20,7 +20,7 @@ class Code extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/view/*', $uri->getPath())) {
+        if (!matchPath('/view/*', $uri->getPath())) {
             return null;
         }
 

--- a/src/Adapters/Wikipedia/Api.php
+++ b/src/Adapters/Wikipedia/Api.php
@@ -5,7 +5,7 @@ namespace Embed\Adapters\Wikipedia;
 
 use function Embed\getDirectory;
 use Embed\HttpApiTrait;
-use function Embed\match;
+use function Embed\matchPath;
 
 class Api
 {
@@ -15,7 +15,7 @@ class Api
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/wiki/*', $uri->getPath())) {
+        if (!matchPath('/wiki/*', $uri->getPath())) {
             return [];
         }
 

--- a/src/Adapters/Youtube/Detectors/Feeds.php
+++ b/src/Adapters/Youtube/Detectors/Feeds.php
@@ -5,7 +5,7 @@ namespace Embed\Adapters\Youtube\Detectors;
 
 use Embed\Detectors\Feeds as Detector;
 use function Embed\getDirectory;
-use function Embed\match;
+use function Embed\matchPath;
 use Psr\Http\Message\UriInterface;
 
 class Feeds extends Detector
@@ -23,7 +23,7 @@ class Feeds extends Detector
     {
         $uri = $this->extractor->getUri();
 
-        if (!match('/channel/*', $uri->getPath())) {
+        if (!matchPath('/channel/*', $uri->getPath())) {
             return [];
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -116,7 +116,7 @@ function cleanPath(string $path): string
     return $path;
 }
 
-function match(string $pattern, string $subject): bool
+function matchPath(string $pattern, string $subject): bool
 {
     $pattern = str_replace('\\*', '.*', preg_quote($pattern, '|'));
 


### PR DESCRIPTION
This PR renames the `match` function (and its references) to fix a parse error in PHP 8, 
as `match` is now a keyword in PHP 8 for [match expressions](https://wiki.php.net/rfc/match_expression_v2).