### PR TITLE
Disable libxml_disable_entity_loader() in PHP 8

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -274,7 +274,11 @@ class Utils
     public static function parse($html)
     {
         $errors = libxml_use_internal_errors(true);
-        $entities = libxml_disable_entity_loader(true);
+
+        // PHP 8 deprecates libxml_disable_entity_loader() as it is no longer needed
+        if (\PHP_VERSION_ID < 80000) {
+            $entities = libxml_disable_entity_loader(true);
+        }
 
         $html = trim(self::normalize($html));
 
@@ -282,7 +286,10 @@ class Utils
         $document->loadHTML($html);
 
         libxml_use_internal_errors($errors);
-        libxml_disable_entity_loader($entities);
+
+        if (\PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($entities);
+        }
 
         return $document;
     }


### PR DESCRIPTION
This method is deprecated in PHP 8, as it is no longer necessary.

(I've raised this against the `v3.x` branch, as this is the version used by [Silverstripe](https://github.com/silverstripe/silverstripe-framework/blob/4/composer.json#L27), and `v4.x` doesn't use this method at all.)