### PR TITLE
Fix Facebook API October 24th changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,17 +328,14 @@ If you need to pass settings to your detectors, you can add settings to the `Ext
 
 ```php
 use Embed\Embed;
-use Embed\ExtractorFactory;
 
 $embed = new Embed();
-$extractorFactory = new ExtractorFactory([
+$embed->setSettings([
     'oembed:query_parameters' => [],  //Extra parameters send to oembed
     'twitch:parent' => 'example.com', //Required to embed twitch videos as iframe
     'facebook:token' => '1234|5678',  //Required to embed content from Facebook
     'instagram:token' => '1234|5678', //Required to embed content from Instagram
 ]);
-$embed->setExtractorFactory($extractorFactory);
-
 $info = $embed->get($url);
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,18 +324,22 @@ $client->setSettings([
 $embed = new Embed(new Crawler($client));
 ```
 
-If you need to pass settings to your detectors, you can use the `setSettings` method:
+If you need to pass settings to your detectors, you can add settings to the `ExtractorFactory`:
 
 ```php
-//Create the extractor
-$info = $embed->get($url);
+use Embed\Embed;
+use Embed\ExtractorFactory;
 
-$info->setSettings([
+$embed = new Embed();
+$extractorFactory = new ExtractorFactory([
     'oembed:query_parameters' => [],  //Extra parameters send to oembed
     'twitch:parent' => 'example.com', //Required to embed twitch videos as iframe
     'facebook:token' => '1234|5678',  //Required to embed content from Facebook
     'instagram:token' => '1234|5678', //Required to embed content from Instagram
 ]);
+$embed->setExtractorFactory($extractorFactory);
+
+$info = $embed->get($url);
 ```
 
 Note: The built-in detectors does not require settings. This feature is only for convenience if you create a specific detector that requires settings.

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "php": "^7.4",
         "ext-curl": "*",
         "ext-dom": "*",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "composer/ca-bundle": "^1.0",
         "oscarotero/html-parser": "^0.1.4",

--- a/demo/index.php
+++ b/demo/index.php
@@ -25,7 +25,8 @@ function getUrl(): ?string
     return $url;
 }
 
-function getParam(string $paramName): ?string {
+function getParam(string $paramName): ?string
+{
     return $_GET[$paramName] ?? null;
 }
 
@@ -183,7 +184,7 @@ $detectors = [
                 </label>
                 <label>
                     <span>Facebook Token:</span>
-                    <input type="text" name="facebook_token" placeholder="1234|5678" value="<?php echo getParam('facebook_token') ?>">
+                    <input type="text" name="facebook_token" placeholder="1234|5678" value="<?php echo getParam('facebook_token'); ?>">
                 </label>
             </fieldset>
 
@@ -194,7 +195,7 @@ $detectors = [
             </fieldset>
         </form>
 
-        <?php if (getUrl()): ?>
+        <?php if (getUrl()) : ?>
         <main>
             <h1>Result:</h1>
 
@@ -224,7 +225,7 @@ $detectors = [
             ?>
 
             <table>
-                <?php foreach ($detectors as $name => $fn): ?>
+                <?php foreach ($detectors as $name => $fn) : ?>
                 <tr>
                     <th><?php echo $name; ?></th>
                     <td><?php $fn($info->$name); ?></td>
@@ -268,7 +269,7 @@ $detectors = [
                         </tr>
                     </table>
 
-                    <?php if (method_exists($info, 'getApi')): ?>
+                    <?php if (method_exists($info, 'getApi')) : ?>
                     <h2>API data</h2>
 
                     <table>

--- a/demo/index.php
+++ b/demo/index.php
@@ -207,14 +207,13 @@ $detectors = [
                     'Cache-Control' => 'max-age=0,no-cache',
                 ]);
 
-                $extractorFactory = new \Embed\ExtractorFactory(
+                $embed->setSettings(
                     [
                         'twitch:parent' => $_SERVER['SERVER_NAME'] === 'localhost' ? null : $_SERVER['SERVER_NAME'],
                         'instagram:token' => getParam('instagram_token'),
                         'facebook:token' => getParam('facebook_token'),
                     ]
                 );
-                $embed->setExtractorFactory($extractorFactory);
                 $info = $embed->get(getUrl());
             } catch (Exception $exception) {
                 echo '<pre>';

--- a/demo/index.php
+++ b/demo/index.php
@@ -6,15 +6,16 @@ include __DIR__.'/../vendor/autoload.php';
 
 function getUrl(): ?string
 {
-    $url = $_GET['url'] ?? null;
+    $skipParams = ['url', 'instagram_token', 'facebook_token'];
+    $url = getParam('url');
 
-    if (empty($url)) {
+    if (!$url) {
         return null;
     }
 
     //fix for unescaped urls
     foreach ($_GET as $name => $value) {
-        if ($name === 'url') {
+        if (in_array($name, $skipParams, true)) {
             continue;
         }
 
@@ -22,6 +23,10 @@ function getUrl(): ?string
     }
 
     return $url;
+}
+
+function getParam(string $paramName): ?string {
+    return $_GET[$paramName] ?? null;
 }
 
 function getEscapedUrl(): ?string
@@ -120,7 +125,6 @@ $detectors = [
     'cms' => 'printText',
     'language' => 'printText',
     'languages' => 'printArray',
-    'cms' => 'printText',
 ];
 ?>
 
@@ -173,6 +177,14 @@ $detectors = [
                     <span>Url to test:</span>
                     <input type="url" name="url" autofocus placeholder="http://" value="<?php echo getEscapedUrl(); ?>">
                 </label>
+                <label>
+                    <span>Instagram Token:</span>
+                    <input type="text" name="instagram_token" placeholder="1234|5678" value="<?php echo getParam('instagram_token'); ?>">
+                </label>
+                <label>
+                    <span>Facebook Token:</span>
+                    <input type="text" name="facebook_token" placeholder="1234|5678" value="<?php echo getParam('facebook_token') ?>">
+                </label>
             </fieldset>
 
             <fieldset class="action">
@@ -193,10 +205,16 @@ $detectors = [
                     'Accept-Language' => 'en-US,en;q=0.2',
                     'Cache-Control' => 'max-age=0,no-cache',
                 ]);
+
+                $extractorFactory = new \Embed\ExtractorFactory(
+                    [
+                        'twitch:parent' => $_SERVER['SERVER_NAME'] === 'localhost' ? null : $_SERVER['SERVER_NAME'],
+                        'instagram:token' => getParam('instagram_token'),
+                        'facebook:token' => getParam('facebook_token'),
+                    ]
+                );
+                $embed->setExtractorFactory($extractorFactory);
                 $info = $embed->get(getUrl());
-                $info->setSettings([
-                    'twitch:parent' => $_SERVER['SERVER_NAME'] === 'localhost' ? null : $_SERVER['SERVER_NAME'],
-                ]);
             } catch (Exception $exception) {
                 echo '<pre>';
                 echo $exception;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"

--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -26,7 +26,7 @@ class OEmbed extends Base
 
         return $this->extractor->getCrawler()
             ->createUri($this->getEndpointByPath($uri->getPath()))
-            ->withQuery($queryParameters);
+            ->withQuery(http_build_query($queryParameters));
     }
 
     private function getEndpointByPath(string $path): string

--- a/src/Adapters/Instagram/OEmbed.php
+++ b/src/Adapters/Instagram/OEmbed.php
@@ -24,6 +24,6 @@ class OEmbed extends Base
 
         return $this->extractor->getCrawler()
             ->createUri(self::ENDPOINT)
-            ->withQuery($queryParameters);
+            ->withQuery(http_build_query($queryParameters));
     }
 }

--- a/src/ApiTrait.php
+++ b/src/ApiTrait.php
@@ -9,7 +9,7 @@ use Throwable;
 
 trait ApiTrait
 {
-    private Extractor $extractor;
+    protected Extractor $extractor;
     private array $data;
 
     public function __construct(Extractor $extractor)

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -81,4 +81,9 @@ class Embed
 
         return $extractor->redirect !== null;
     }
+
+    public function setExtractorFactory(ExtractorFactory $extractorFactory): void
+    {
+        $this->extractorFactory = $extractorFactory;
+    }
 }

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -57,6 +57,11 @@ class Embed
         return $this->extractorFactory;
     }
 
+    public function setSettings(array $settings): void
+    {
+        $this->extractorFactory->setSettings($settings);
+    }
+
     private function extract(RequestInterface $request, ResponseInterface $response, bool $redirect = true): Extractor
     {
         $uri = $this->crawler->getResponseUri($response) ?: $request->getUri();
@@ -80,10 +85,5 @@ class Embed
         }
 
         return $extractor->redirect !== null;
-    }
-
-    public function setExtractorFactory(ExtractorFactory $extractorFactory): void
-    {
-        $this->extractorFactory = $extractorFactory;
     }
 }

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -62,7 +62,7 @@ class Extractor
     private Crawler $crawler;
 
     private Document $document;
-    private OEmbed $oembed;
+    protected OEmbed $oembed;
     private LinkedData $linkedData;
     private Metas $metas;
 

--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -33,6 +33,12 @@ class ExtractorFactory
         'twitch.tv' => Adapters\Twitch\Extractor::class,
     ];
     private array $customDetectors = [];
+    private array $settings;
+
+    public function __construct(?array $settings = [])
+    {
+        $this->settings = $settings ?? [];
+    }
 
     public function createExtractor(UriInterface $uri, RequestInterface $request, ResponseInterface $response, Crawler $crawler): Extractor
     {
@@ -41,7 +47,9 @@ class ExtractorFactory
 
         $class = $this->adapters[$host] ?? $this->default;
 
+        /** @var Extractor $extractor */
         $extractor = new $class($uri, $request, $response, $crawler);
+        $extractor->setSettings($this->settings);
 
         foreach ($this->customDetectors as $name => $detector) {
             $extractor->addDetector($name, new $detector($extractor));

--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -77,4 +77,9 @@ class ExtractorFactory
     {
         $this->default = $class;
     }
+
+    public function setSettings(array $settings): void
+    {
+        $this->settings = $settings;
+    }
 }

--- a/tests/PagesTest.php
+++ b/tests/PagesTest.php
@@ -33,7 +33,6 @@ class PagesTest extends PagesTestCase
         $this->assertEmbed('http://www.hookem.com/story/texas-shortstop-joe-baker-arrested-public-intoxication/');
         $this->assertEmbed('http://i.imgur.com/X6rkCc5.jpg');
         $this->assertEmbed('https://infogr.am/7743c36a-f3ca-4465-9a80-a8abbd5d8dc4');
-        $this->assertEmbed('https://www.instagram.com/p/ySl7G9tO_q/');
         $this->assertEmbed('http://output.jsbin.com/vonesu/10');
         $this->assertEmbed('http://jsfiddle.net/zhm5rjnz/');
         $this->assertEmbed('https://www.kickstarter.com/projects/1452363698/good-seed-craft-veggie-burgers');
@@ -91,7 +90,11 @@ class PagesTest extends PagesTestCase
 
     public function testInstagram()
     {
-        $this->assertEmbed('http://instagram.com/p/ySl7G9tO_q/');
+        if ($_ENV['INSTAGRAM_TOKEN'] ?? false) {
+            $this->assertEmbed('http://instagram.com/p/ySl7G9tO_q/');
+        } else {
+            self::markTestSkipped('Environment variable `INSTAGRAM_TOKEN` must be provided to test instagram. See https://developers.facebook.com/docs/instagram/oembed/');
+        }
     }
 
     public function testMeetup()
@@ -127,8 +130,12 @@ class PagesTest extends PagesTestCase
 
     public function testFacebook()
     {
-        $this->assertEmbed('https://www.facebook.com/permalink.php?story_fbid=827163017327807&id=149460691764713');
-        $this->assertEmbed('https://www.facebook.com/acolono/videos/10154107990797381/');
+        if ($_ENV['FACEBOOK_TOKEN'] ?? false) {
+            $this->assertEmbed('https://www.facebook.com/permalink.php?story_fbid=827163017327807&id=149460691764713');
+            $this->assertEmbed('https://www.facebook.com/acolono/videos/10154107990797381/');
+        } else {
+            self::markTestSkipped('Environment variable `FACEBOOK_TOKEN` must be provided to test facebook. See https://developers.facebook.com/docs/plugins/oembed');
+        }
     }
 
     public function testGithub()

--- a/tests/PagesTest.php
+++ b/tests/PagesTest.php
@@ -90,7 +90,7 @@ class PagesTest extends PagesTestCase
 
     public function testInstagram()
     {
-        if ($_ENV['INSTAGRAM_TOKEN'] ?? false) {
+        if (getenv('INSTAGRAM_TOKEN') ?? false) {
             $this->assertEmbed('http://instagram.com/p/ySl7G9tO_q/');
         } else {
             self::markTestSkipped('Environment variable `INSTAGRAM_TOKEN` must be provided to test instagram. See https://developers.facebook.com/docs/instagram/oembed/');
@@ -130,7 +130,7 @@ class PagesTest extends PagesTestCase
 
     public function testFacebook()
     {
-        if ($_ENV['FACEBOOK_TOKEN'] ?? false) {
+        if (getenv('FACEBOOK_TOKEN') ?? false) {
             $this->assertEmbed('https://www.facebook.com/permalink.php?story_fbid=827163017327807&id=149460691764713');
             $this->assertEmbed('https://www.facebook.com/acolono/videos/10154107990797381/');
         } else {

--- a/tests/PagesTestCase.php
+++ b/tests/PagesTestCase.php
@@ -7,6 +7,7 @@ use Brick\VarExporter\VarExporter;
 use Datetime;
 use Embed\Embed;
 use Embed\Extractor;
+use Embed\ExtractorFactory;
 use Embed\Http\Crawler;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +51,7 @@ abstract class PagesTestCase extends TestCase
         $dispatcher = new FileClient(__DIR__.'/cache');
         $dispatcher->setMode(static::CACHE);
 
-        return self::$embed = new Embed(new Crawler($dispatcher));
+        return self::$embed = new Embed(new Crawler($dispatcher), self::getExtractorFactory());
     }
 
     protected function assertEmbed(string $url)
@@ -65,6 +66,7 @@ abstract class PagesTestCase extends TestCase
         if (!$expected || static::FIXTURES === 1) {
             self::writeData($uri, $data);
             echo PHP_EOL."Save fixture: {$url}";
+            $this->markTestSkipped('Skipped assertion for '.$url);
         } else {
             $this->assertEquals($expected, $data, $url);
         }
@@ -132,5 +134,15 @@ abstract class PagesTestCase extends TestCase
         }
 
         return $value;
+    }
+
+    private static function getExtractorFactory()
+    {
+        $settings = [
+            'instagram:token' => $_ENV['INSTAGRAM_TOKEN'] ?? null,
+            'facebook:token' => $_ENV['FACEBOOK_TOKEN'] ?? null,
+        ];
+
+        return new ExtractorFactory($settings);
     }
 }


### PR DESCRIPTION
As described in #392 facebook did change it's API for oembed and now requires a `access_token` for getting oembed data.
@oscarotero prepared Extractors for this case but the settings could only be set "too late". 
https://github.com/oscarotero/Embed/commit/48e39187ed9b60c65672320206141c59c121e6ad

With this PR it's now possible to provide the settings to the ExtractorFactory.

```php
                $embed = new Embed\Embed();
                $extractorFactory = new \Embed\ExtractorFactory(
                    [
                        'instagram:token' => '1234|5678',
                        'facebook:token' => '1234|5678',
                    ]
                );
                $embed->setExtractorFactory($extractorFactory);
                $embed->get($url);
```

solves #392 