### PR TITLE
fix(facebook): oembed for photos on pages does not work

### DIFF
--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -53,9 +53,12 @@ class OEmbed extends Base
         https://www.facebook.com/media/set?set={set-id}
         https://www.facebook.com/questions/{question-id}
         https://www.facebook.com/notes/{username}/{note-url}/{note-id}
+
+        Not in the facebook docs:
+        https://www.facebook.com/{page-name}/photos/{post-id}/{photo-id}
         */
         if (strpos($path, '/photo.php') === 0
-            || strpos($path, '/photos/') === 0
+            || strpos($path, '/photos/') !== false
             || strpos($path, '/permalink.php') === 0
             || strpos($path, '/media/') === 0
             || strpos($path, '/questions/') === 0


### PR DESCRIPTION
With this commit urls of scheme https://www.facebook.com/{page-name}/photos/{post-id}/{photo-id}
will use the oembed_post endpoint

resolves: oscarotero/Embed#405