### PR TITLE
Add an Instagram Adapter to v3.x

### DIFF
--- a/src/Adapters/Instagram.php
+++ b/src/Adapters/Instagram.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Embed\Adapters;
+
+use Embed\Http\Response;
+
+/**
+ * Adapter to provide information from Instagram.
+ * Required when Instagram returns a 429 status code.
+ */
+class Instagram extends Webpage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function check(Response $response)
+    {
+        return $response->isValid([200, 429]);
+    }
+}

--- a/src/Http/Redirects.php
+++ b/src/Http/Redirects.php
@@ -13,26 +13,7 @@ abstract class Redirects
         'hashBang' => '*#!*',
         'spotify' => 'play.spotify.com/*',
         'tumblr' => 't.umblr.com/redirect',
-        'facebook' => 'www.facebook.com/login/*',
     ];
-
-    /**
-     * Resolve the url redirection.
-     *
-     * @param Url $url
-     *
-     * @return Url
-     */
-    public static function resolve(Url $url)
-    {
-        foreach (self::$patterns as $method => $pattern) {
-            if ($url->match($pattern)) {
-                return self::$method($url);
-            }
-        }
-
-        return $url;
-    }
     
      /**
      * Resolve a facebook redirection url.

--- a/src/Http/Redirects.php
+++ b/src/Http/Redirects.php
@@ -13,6 +13,7 @@ abstract class Redirects
         'hashBang' => '*#!*',
         'spotify' => 'play.spotify.com/*',
         'tumblr' => 't.umblr.com/redirect',
+        'facebook' => 'www.facebook.com/login/*',
     ];
 
     /**
@@ -28,6 +29,22 @@ abstract class Redirects
             if ($url->match($pattern)) {
                 return self::$method($url);
             }
+        }
+
+        return $url;
+    }
+    
+     /**
+     * Resolve a facebook redirection url.
+     *
+     * @param Url $url
+     *
+     * @return Url
+     */
+    public static function facebook(Url $url)
+    {
+        if (($value = $url->getQueryParameter('next'))) {
+            return Url::create($value);
         }
 
         return $url;

--- a/src/Http/Redirects.php
+++ b/src/Http/Redirects.php
@@ -15,17 +15,19 @@ abstract class Redirects
         'tumblr' => 't.umblr.com/redirect',
     ];
     
-     /**
-     * Resolve a facebook redirection url.
+    /**
+     * Resolve the url redirection.
      *
      * @param Url $url
      *
      * @return Url
      */
-    public static function facebook(Url $url)
+    public static function resolve(Url $url)
     {
-        if (($value = $url->getQueryParameter('next'))) {
-            return Url::create($value);
+        foreach (self::$patterns as $method => $pattern) {
+            if ($url->match($pattern)) {
+                return self::$method($url);
+            }
         }
 
         return $url;


### PR DESCRIPTION
When attempting to process Instagram posts in Embed::process(),  $response = $dispatcher->dispatch($url); returns an error code (429) because the URL does not use the IG endpoint with the access token. (On localhost environments it returns 200, but not when it's on a production server).

Since the response has an error code, The default Webpage adapter it uses fails on $adapter::check($response) and it never gets a chance to check the url with the correct endpoint and token.

Here I added an adapter file for Instagram that passes for 200 or 429 codes

I'm not sure if Facebook posts need to do this as well, since they both require the same token.

see my initial comment here: https://github.com/oscarotero/Embed/issues/411#issuecomment-743373703