### PR TITLE
Handle facebook login page redirects in v3.x

### DIFF
--- a/src/Http/Redirects.php
+++ b/src/Http/Redirects.php
@@ -13,6 +13,7 @@ abstract class Redirects
         'hashBang' => '*#!*',
         'spotify' => 'play.spotify.com/*',
         'tumblr' => 't.umblr.com/redirect',
+        'facebook' => 'www.facebook.com/login/*',
     ];
     
     /**
@@ -32,6 +33,23 @@ abstract class Redirects
 
         return $url;
     }
+
+    /**
+     * Resolve a facebook redirection url.
+     *
+     * @param Url $url
+     *
+     * @return Url
+     */
+    public static function facebook(Url $url)
+    {
+        if (($value = $url->getQueryParameter('next'))) {
+            return Url::create($value);
+        }
+
+        return $url;
+    }
+
 
     /**
      * Resolve a google redirection url.


### PR DESCRIPTION
Ok so, here is the fix I needed to get v3.x working with Facebook.

The issue here is that some facebook urls that are redirecting to the login page and then returning a "invalid parameter" error from FB, Because you cant embed the login page. It a little strange and inconsistent, sometimes they redirect other times they don't. 

Ones in this old format tend to work
https://www.facebook.com/permalink.php?story_fbid={post-id}

While the same one using the current format do not.
https://www.facebook.com/*/posts/{post-id}

To fix this I added a pattern for "www.facebook.com/login/*" to the Redirects.php class and get the intended url from the "next" parameter. This resolves the issue for me.

original issue here https://github.com/oscarotero/Embed/issues/415