### PR TITLE
Update YouTube Oembed adapter to work with new consent page (fixes #434)

### DIFF
--- a/src/Providers/OEmbed/Youtube.php
+++ b/src/Providers/OEmbed/Youtube.php
@@ -2,8 +2,25 @@
 
 namespace Embed\Providers\OEmbed;
 
+use Embed\Adapters\Adapter;
+
 class Youtube extends EndPoint implements EndPointInterface
 {
     protected static $pattern = ['*youtube.*', '*youtu\.be.*'];
     protected static $endPoint = 'https://www.youtube.com/oembed';
+
+    public static function create(Adapter $adapter)
+    {
+        $response = $adapter->getResponse();
+        // If the starting URL is a valid YouTube URL, but we've been redirected to a consent page,
+        // we should attempt to get Oembed using the original URL instead of the consent URL
+        if (
+            preg_match('/consent\.youtube.*/', $response->getUrl())
+            && $response->getStartingUrl()->match(static::$pattern)
+        ) {
+            return new static($response, $response->getStartingUrl());
+        }
+
+        return parent::create($adapter);
+    }
 }


### PR DESCRIPTION
Fixes #434 

I’m only aware of the page being served on the `consent.youtube.com` domain, but the regex might need expanding in future if people find other domains YouTube are serving the consent page from.