### PR TITLE
Fix broken match pattern for youtu.be URLs

### DIFF
--- a/src/Providers/OEmbed/Youtube.php
+++ b/src/Providers/OEmbed/Youtube.php
@@ -6,7 +6,7 @@ use Embed\Adapters\Adapter;
 
 class Youtube extends EndPoint implements EndPointInterface
 {
-    protected static $pattern = ['*youtube.*', '*youtu\.be.*'];
+    protected static $pattern = ['*youtube.*', '*youtu.be*'];
     protected static $endPoint = 'https://www.youtube.com/oembed';
 
     public static function create(Adapter $adapter)


### PR DESCRIPTION
This pattern didn’t work as expected previously anyway, as the `.` doesn’t need to be escaped (due to `preg_quote()`) and `.*` ends up being changed to `\..*`:

https://github.com/oscarotero/Embed/blob/f944eef58227af79d217b48c763ae931cf417828/src/Http/Url.php#L80