### PR TITLE
Fixed #441: force type to string when overriding adapter url

### DIFF
--- a/src/Providers/OEmbed/Youtube.php
+++ b/src/Providers/OEmbed/Youtube.php
@@ -21,7 +21,7 @@ class Youtube extends EndPoint implements EndPointInterface
             // The Adapter URL should be forced to starting URL as well
             // to prevent consumers of the packages having to deal
             // with a URL to a consent page (#441)
-            $adapter->url = $response->getStartingUrl();
+            $adapter->url = (string) $response->getStartingUrl();
             return new static($response, $response->getStartingUrl());
         }
 


### PR DESCRIPTION
This so the adapter will comply with the definition of `getUrl()`-method. When `$url` is not set, magic getter resolves `getUrl()` and therefor consumers will be expecting a string, not an object (even though Url implements `__toString()`).

This was not caught through unit tests as Url implements __toString and the used assertion converted the Url object to a string type instead of failing.