### PR TITLE
Update Iframely.php to fix URL error

### DIFF
--- a/src/Providers/OEmbed/Iframely.php
+++ b/src/Providers/OEmbed/Iframely.php
@@ -42,7 +42,7 @@ class Iframely implements EndPointInterface
     {
         return Url::create('http://open.iframe.ly/api/oembed')
                 ->withQueryParameters([
-                    'url' => (string) $this->getUrl(),
+                    'url' => (string) $this->response->getUrl(),
                     'format' => 'json',
                     'api_key' => $this->key,
                 ]);


### PR DESCRIPTION
An error is thrown when trying to access `getUrl` from `$this`, instead we need to use `getUrl` on the response object on line 45.