### PR TITLE
Follow Facebook login redirect

### DIFF
--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -8,9 +8,9 @@ use Psr\Http\Message\UriInterface;
 
 class OEmbed extends Base
 {
-    const ENDPOINT_PAGE = 'https://graph.facebook.com/v8.0/oembed_page';
-    const ENDPOINT_POST = 'https://graph.facebook.com/v8.0/oembed_post';
-    const ENDPOINT_VIDEO = 'https://graph.facebook.com/v8.0/oembed_video';
+    const ENDPOINT_PAGE = 'https://graph.facebook.com/v11.0/oembed_page';
+    const ENDPOINT_POST = 'https://graph.facebook.com/v11.0/oembed_post';
+    const ENDPOINT_VIDEO = 'https://graph.facebook.com/v11.0/oembed_video';
 
     protected function detectEndpoint(): ?UriInterface
     {
@@ -21,6 +21,16 @@ class OEmbed extends Base
         }
 
         $uri = $this->extractor->getUri();
+        if (strpos($uri->getPath(), 'login') !== false) {
+            $query = $uri->getQuery();
+            $params = explode('&', $query);
+            foreach ($params as $param) {
+                $keyval = explode('=', $param);
+                if ($keyval[0] == 'next') {
+                    $uri = $this->extractor->getCrawler()->createUri(rawurldecode($keyval[1]));
+                }
+            }
+        }
         $queryParameters = $this->getOembedQueryParameters((string) $uri);
         $queryParameters['access_token'] = $token;
 

--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -22,13 +22,9 @@ class OEmbed extends Base
 
         $uri = $this->extractor->getUri();
         if (strpos($uri->getPath(), 'login') !== false) {
-            $query = $uri->getQuery();
-            $params = explode('&', $query);
-            foreach ($params as $param) {
-                $keyval = explode('=', $param);
-                if ($keyval[0] == 'next') {
-                    $uri = $this->extractor->getCrawler()->createUri(rawurldecode($keyval[1]));
-                }
+            parse_str($uri->getQuery(), $params);
+            if (isset($params['next']) && $params['next']) {
+                $uri = $this->extractor->getCrawler()->createUri($params['next']);
             }
         }
         $queryParameters = $this->getOembedQueryParameters((string) $uri);

--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -23,7 +23,7 @@ class OEmbed extends Base
         $uri = $this->extractor->getUri();
         if (strpos($uri->getPath(), 'login') !== false) {
             parse_str($uri->getQuery(), $params);
-            if (isset($params['next']) && $params['next']) {
+            if (!empty($params['next'])) {
                 $uri = $this->extractor->getCrawler()->createUri($params['next']);
             }
         }


### PR DESCRIPTION
Facebook redirects to login for all posts, but with a token the OEmbed info is still readable. This change gets the original url from the `next` query parameter of the redirected login and queries the relevant oembed endpoint.

Fixes https://github.com/oscarotero/Embed/issues/450