### PR TITLE
Avoid reading oEmbed data from instagram login page

### DIFF
--- a/src/Adapters/Instagram/OEmbed.php
+++ b/src/Adapters/Instagram/OEmbed.php
@@ -19,6 +19,10 @@ class OEmbed extends Base
         }
 
         $uri = $this->extractor->getUri();
+        if (strpos($uri->getPath(), 'login') !== false) {
+            $uri = $this->extractor->getRequest()->getUri();
+        }
+        
         $queryParameters = $this->getOembedQueryParameters((string) $uri);
         $queryParameters['access_token'] = $token;
 


### PR DESCRIPTION
Fix for https://github.com/oscarotero/Embed/issues/456

oEmbed now works for instagram and returns an object like this : 
```
[
  "version" => "..."
  "author_name" => "..."
  "provider_name" => "..."
  "provider_url" => "..."
  "type" => "..."
  "width" => "..."
  "html" => "..."
  "thumbnail_url" => "..."
  "thumbnail_width" => "..."
  "thumbnail_height" => "..."
]
```

`$embed->title` is still `"Login • Instagram"`
`$embed->description` is still `"Welcome back to Instagram. Sign in to check out what your friends, family & interests have been capturing & sharing around the world."`

Maybe we could extract these informations from the oEmbed html code ? 