### PR TITLE
Fix $node being overwritten in LinkedData.php

### DIFF
--- a/src/LinkedData.php
+++ b/src/LinkedData.php
@@ -72,14 +72,14 @@ class LinkedData
     private static function getValue(Node $node, string ...$keys)
     {
         foreach ($keys as $key) {
-            $node = $node->getProperty("http://schema.org/{$key}");
+            $value = $node->getProperty("http://schema.org/{$key}");
 
-            if (!$node) {
+            if (!$value) {
                 return null;
             }
         }
 
-        return self::detectValue($node);
+        return self::detectValue($value);
     }
 
     private static function detectValue($value)


### PR DESCRIPTION
I don't 100% understand what the code's doing here, but overwriting $node is pretty obviously not the intent. If more than one key is passed in, the code would die because $node was no longer a Node object.

It's probably worth having someone who understands it better figuring out what should be done here, because it doesn't seem to be useful code if more than one key is passed in.