### PR TITLE
Fix regression in OEmbed provider Embedly

### DIFF
--- a/src/Providers/OEmbed/Embedly.php
+++ b/src/Providers/OEmbed/Embedly.php
@@ -42,7 +42,7 @@ class Embedly implements EndPointInterface
     {
         return Url::create('http://api.embed.ly/1/oembed')
                 ->withQueryParameters([
-                    'url' => (string) $this->getUrl(),
+                    'url' => (string) $this->response->getUrl(),
                     'format' => 'json',
                     'key' => $this->key,
                 ]);


### PR DESCRIPTION
Looks like providers have been overhauled in v4 so this is for those of us using Embedly on v3.
For now I'll revert to v3.4.4, the last release before this regression appeared.