### PR TITLE
Fix for quotation marks in redirect URL

### DIFF
--- a/src/Detectors/Redirect.php
+++ b/src/Detectors/Redirect.php
@@ -18,7 +18,7 @@ class Redirect extends Detector
     private function extract(string $value): ?UriInterface
     {
         if (preg_match('/url=(.+)$/i', $value, $match)) {
-            return $this->extractor->resolveUri($match[1]);
+            return $this->extractor->resolveUri(trim($match[1], '\'"'));
         }
 
         return null;


### PR DESCRIPTION
Some websites use quotation marks around the `url=` query in the meta-refresh tag.

Example:
https://presse.stuttgart-tourist.de/die-weihnachtsmaerkte-in-der-region-stuttgart

`<meta HTTP-EQUIV="refresh" content="0;url='https://presse.stuttgart-tourist.de/die-weihnachtsmaerkte-in-der-region-stuttgart?PageSpeed=noscript'" />`

Those have to be trimmed or an error (`GuzzleHttp\Psr7\Exception\MalformedUriException: A relative URI must not have a path beginning with a segment containing a colon`) is triggered