### PR TITLE
Remove deprecated interpolation in functions.php

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -33,7 +33,7 @@ function html(string $tagName, array $attributes, string $content = null): strin
     }
 
     if ($tagName === 'img') {
-        return "${html} />";
+        return "$html />";
     }
 
     return "{$html}>{$content}</{$tagName}>";


### PR DESCRIPTION
`${var}` interpolation will be deprecated in php8.2. With this fix it is replaced with simple interpolation inside double quotes.

Link to RFC: [https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)