### PR TITLE
Prevent unsupported operand types exception

### DIFF
--- a/src/OEmbed.php
+++ b/src/OEmbed.php
@@ -165,7 +165,7 @@ class OEmbed
         try {
             $data = json_decode($json, true);
 
-            return $data ? ($data + $this->defaults) : [];
+            return is_array($data) ? ($data + $this->defaults) : [];
         } catch (Exception $exception) {
             return [];
         }


### PR DESCRIPTION
Critical exception: Unsupported operand types exception string + array
when 166:$data === 'Internal Server Error'