### PR TITLE
Use correct method for string length

### DIFF
--- a/src/Http/CurlDispatcher.php
+++ b/src/Http/CurlDispatcher.php
@@ -210,7 +210,7 @@ final class CurlDispatcher
         }
 
         if ($this->body->getSize() > self::$contentLengthThreshold) {
-            return count($string);
+            return strlen($string);
         }
 
         return $this->body->write($string);


### PR DESCRIPTION
In my previous PR I accidentally used `count` instead of `strlen` to get the length of a string but `count` only works with arrays.