### PR TITLE
Lookup x.com urls using publish.twitter.com

### DIFF
--- a/src/resources/oembed.php
+++ b/src/resources/oembed.php
@@ -984,6 +984,9 @@ return [
         '|^https?://twitter\\.com/.*$|i',
         '|^https?://twitter\\.com/.*/status/.*$|i',
         '|^https?://.*\\.twitter\\.com/.*/status/.*$|i',
+        '|^https?://x\\.com/.*$|i',
+        '|^https?://x\\.com/.*/status/.*$|i',
+        '|^https?://.*\\.x\\.com/.*/status/.*$|i',
     ],
     'https://play.typecast.ai/oembed' => [
         '|^https?://play\\.typecast\\.ai/s/.*$|i',


### PR DESCRIPTION
Now that Twitter is forcing more front-end urls to x.com, embedding x.com urls [https:/x.com/API/status/1050118621198921728](https:/x.com/API/status/1050118621198921728) can still use the [https://publish.twitter.com/oembed](https://publish.twitter.com/oembed) endpoint.

Added x.com url matching to `resources/oembed.php` under `'https://publish.twitter.com/oembed'`.

Also works equally well under its own x.com key. This strategy might be a little more future-proof if they ever fully move the developer tools over to x.com, but currently publish.x.com/oembed is just a redirect back to publish.twitter.com/oembed.

```
   'https://publish.x.com/oembed' => [
        '|^https?://x\\.com/.*$|i',
        '|^https?://x\\.com/.*/status/.*$|i',
        '|^https?://.*\\.x\\.com/.*/status/.*$|i',
    ],
```