### PR TITLE
fix php 8.4 deprecation message

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -18,7 +18,7 @@ function clean(string $value, bool $allowHTML = false): ?string
     return $value === '' ? null : $value;
 }
 
-function html(string $tagName, array $attributes, string $content = null): string
+function html(string $tagName, array $attributes, ?string $content = null): string
 {
     $html = "<{$tagName}";
 


### PR DESCRIPTION
Otherwise you get
Deprecated: Embed\html(): Implicitly marking parameter $content as nullable is deprecated, the explicit nullable type must be used instead

this should work fine on all supported php versions