### PR TITLE
Improved charset tag recognition accuracy.

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -28,13 +28,30 @@ class Document
 
         $encoding = null;
         $contentType = $extractor->getResponse()->getHeaderLine('content-type');
-        preg_match('/charset="?(.*?)(?=$|\s|;|")/i', $contentType, $match);
+        preg_match('/charset=(?:"|\')?(.*?)(?=$|\s|;|"|\'|>)/i', $contentType, $match);
         if (!empty($match[1])) {
             $encoding = trim($match[1], ',');
-        } elseif (!empty($html)) {
-            preg_match('/charset="?(.*?)(?=$|\s|;|")/i', $html, $match);
+            try {
+                $ret = mb_encoding_aliases($encoding);
+                if ($ret === false) {
+                    $encoding = null;
+                }
+            } catch (\ValueError $exception) {
+                $encoding = null;
+            }
+        }
+        if (is_null($encoding) && !empty($html)) {
+            preg_match('/charset=(?:"|\')?(.*?)(?=$|\s|;|"|\'|>)/i', $html, $match);
             if (!empty($match[1])) {
                 $encoding = trim($match[1], ',');
+            }
+            try {
+                $ret = mb_encoding_aliases($encoding);
+                if ($ret === false) {
+                    $encoding = null;
+                }
+            } catch (\ValueError $exception) {
+                $encoding = null;
             }
         }
         $this->document = !empty($html) ? Parser::parse($html, $encoding) : new DOMDocument();


### PR DESCRIPTION
Will be able to recognize was NG.

```
OK) <meta charset="utf-8">
NG) <meta charset='utf-8'>
NG) <meta charset=utf-8>
```

and the error occurred when charset was incorrectly specified, so it is now automatically recognized as before.