### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -107,7 +107,7 @@ class Document
     /**
      * Select a element in the dom
      */
-    public function select(string $query, array $attributes = null, DOMNode $context = null): QueryResult
+    public function select(string $query, ?array $attributes = null, ?DOMNode $context = null): QueryResult
     {
         if (!empty($attributes)) {
             $query = self::buildQuery($query, $attributes);
@@ -119,7 +119,7 @@ class Document
     /**
      * Select a element in the dom using a css selector
      */
-    public function selectCss(string $query, DOMNode $context = null): QueryResult
+    public function selectCss(string $query, ?DOMNode $context = null): QueryResult
     {
         return $this->select(self::cssToXpath($query), null, $context);
     }

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -12,7 +12,7 @@ class Embed
     private Crawler $crawler;
     private ExtractorFactory $extractorFactory;
 
-    public function __construct(Crawler $crawler = null, ExtractorFactory $extractorFactory = null)
+    public function __construct(?Crawler $crawler = null, ?ExtractorFactory $extractorFactory = null)
     {
         $this->crawler = $crawler ?: new Crawler();
         $this->extractorFactory = $extractorFactory ?: new ExtractorFactory();

--- a/src/EmbedCode.php
+++ b/src/EmbedCode.php
@@ -13,7 +13,7 @@ class EmbedCode implements JsonSerializable
     public ?int $height;
     public ?float $ratio = null;
 
-    public function __construct(string $html, int $width = null, int $height = null)
+    public function __construct(string $html, ?int $width = null, ?int $height = null)
     {
         $this->html = $html;
         $this->width = $width;

--- a/src/Http/Crawler.php
+++ b/src/Http/Crawler.php
@@ -20,7 +20,7 @@ class Crawler implements ClientInterface, RequestFactoryInterface, UriFactoryInt
         'Cache-Control' => 'max-age=0',
     ];
 
-    public function __construct(ClientInterface $client = null, RequestFactoryInterface $requestFactory = null, UriFactoryInterface $uriFactory = null)
+    public function __construct(?ClientInterface $client = null, ?RequestFactoryInterface $requestFactory = null, ?UriFactoryInterface $uriFactory = null)
     {
         $this->client = $client ?: new CurlClient();
         $this->requestFactory = $requestFactory ?: FactoryDiscovery::getRequestFactory();

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -16,7 +16,7 @@ final class CurlClient implements ClientInterface
     private ResponseFactoryInterface $responseFactory;
     private array $settings = [];
 
-    public function __construct(ResponseFactoryInterface $responseFactory = null)
+    public function __construct(?ResponseFactoryInterface $responseFactory = null)
     {
         $this->responseFactory = $responseFactory ?: FactoryDiscovery::getResponseFactory();
     }

--- a/src/Http/CurlDispatcher.php
+++ b/src/Http/CurlDispatcher.php
@@ -83,7 +83,7 @@ final class CurlDispatcher
         );
     }
 
-    private function __construct(array $settings, RequestInterface $request, StreamFactoryInterface $streamFactory = null)
+    private function __construct(array $settings, RequestInterface $request, ?StreamFactoryInterface $streamFactory = null)
     {
         $this->request = $request;
         $this->curl = curl_init((string) $request->getUri());

--- a/src/LinkedData.php
+++ b/src/LinkedData.php
@@ -51,7 +51,7 @@ class LinkedData
         return $this->allData;
     }
 
-    private function getGraph(string $name = null): ?GraphInterface
+    private function getGraph(?string $name = null): ?GraphInterface
     {
         if (!isset($this->document)) {
             try {

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -37,7 +37,7 @@ class QueryResult
         return $this;
     }
 
-    public function get(string $attribute = null)
+    public function get(?string $attribute = null)
     {
         $node = $this->node();
 
@@ -48,7 +48,7 @@ class QueryResult
         return $attribute ? self::getAttribute($node, $attribute) : $node->nodeValue;
     }
 
-    public function getAll(string $attribute = null): array
+    public function getAll(?string $attribute = null): array
     {
         $nodes = $this->nodes();
 
@@ -60,26 +60,26 @@ class QueryResult
         );
     }
 
-    public function str(string $attribute = null): ?string
+    public function str(?string $attribute = null): ?string
     {
         $value = $this->get($attribute);
 
         return $value ? clean($value) : null;
     }
 
-    public function strAll(string $attribute = null): array
+    public function strAll(?string $attribute = null): array
     {
         return array_filter(array_map(fn ($value) => clean($value), $this->getAll($attribute)));
     }
 
-    public function int(string $attribute = null): ?int
+    public function int(?string $attribute = null): ?int
     {
         $value = $this->get($attribute);
 
         return $value ? (int) $value : null;
     }
 
-    public function url(string $attribute = null): ?UriInterface
+    public function url(?string $attribute = null): ?UriInterface
     {
         $value = $this->get($attribute);
 


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter