### PR TITLE
Substitute nonstandard HTTP 999 Forbidden with 403 Forbidden (LinkedIn)

### DIFF
--- a/src/Http/CurlDispatcher.php
+++ b/src/Http/CurlDispatcher.php
@@ -128,6 +128,9 @@ final class CurlDispatcher
 
         curl_close($this->curl);
 
+        if ($info['http_code'] === 999) {
+            $info['http_code'] = 403;
+        }
         $response = $responseFactory->createResponse($info['http_code']);
 
         foreach ($this->headers as $header) {


### PR DESCRIPTION
## Purpose
Resolves #557