### PR TITLE
fix: wrong mb_encoding_aliases() handling for PHP 8.0+

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -74,9 +74,9 @@ class Document
         } else {
             // PHP 8.0+: ValueError exception is thrown for invalid/empty encoding
             try {
-                $aliases = mb_encoding_aliases($encoding ?? '');
-                // Check if aliases array is not empty (valid encoding should have at least one alias)
-                return !empty($aliases) ? $encoding : null;
+                mb_encoding_aliases($encoding ?? '');
+                // If mb_encoding_aliases succeeds, return the input value as is. Some encodings do not have aliases.
+                return $encoding;
             } catch (\ValueError $exception) {
                 return null;
             }


### PR DESCRIPTION
The judgement that an empty array return from mb_encoding_aliases indicates an invalid encoding name was incorrect.

## sample.

```
# php 8.0+

## get all list
php > var_dump(mb_list_encodings());
<snip>
  [61]=>
  string(2) "HZ"
<snip>
}

## HZ does not have aliases, but that's not an error.
php > var_dump(mb_encoding_aliases("HZ"));
array(0) {
}

# php 7.4 (same as 8.0+)
php > var_dump(mb_encoding_aliases("HZ"));
array(0) {
}
```
