### PR TITLE
refactor: add PHPStan generic type annotations and simplify detector implementations

### DIFF
--- a/src/Adapters/Archive/Detectors/AuthorName.php
+++ b/src/Adapters/Archive/Detectors/AuthorName.php
@@ -12,8 +12,7 @@ class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('metadata', 'creator');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Archive/Detectors/AuthorName.php
+++ b/src/Adapters/Archive/Detectors/AuthorName.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Archive\Detectors;
 
-use Embed\Adapters\Archive\Extractor;
 use Embed\Detectors\AuthorName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Archive/Detectors/Code.php
+++ b/src/Adapters/Archive/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Archive/Detectors/Description.php
+++ b/src/Adapters/Archive/Detectors/Description.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Archive\Detectors;
 
-use Embed\Adapters\Archive\Extractor;
 use Embed\Detectors\Description as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class Description extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Archive/Detectors/Description.php
+++ b/src/Adapters/Archive/Detectors/Description.php
@@ -12,8 +12,7 @@ class Description extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('metadata', 'extract');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Archive/Detectors/ProviderName.php
+++ b/src/Adapters/Archive/Detectors/ProviderName.php
@@ -5,6 +5,9 @@ namespace Embed\Adapters\Archive\Detectors;
 
 use Embed\Detectors\ProviderName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class ProviderName extends Detector
 {
     public function detect(): string

--- a/src/Adapters/Archive/Detectors/PublishedTime.php
+++ b/src/Adapters/Archive/Detectors/PublishedTime.php
@@ -13,8 +13,7 @@ class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $fields = ['publicdate', 'addeddate', 'date'];
         foreach ($fields as $field) {

--- a/src/Adapters/Archive/Detectors/PublishedTime.php
+++ b/src/Adapters/Archive/Detectors/PublishedTime.php
@@ -4,14 +4,15 @@ declare(strict_types = 1);
 namespace Embed\Adapters\Archive\Detectors;
 
 use DateTime;
-use Embed\Adapters\Archive\Extractor;
 use Embed\Detectors\PublishedTime as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Archive/Detectors/Title.php
+++ b/src/Adapters/Archive/Detectors/Title.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Archive\Detectors;
 
-use Embed\Adapters\Archive\Extractor;
 use Embed\Detectors\Title as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Archive\Extractor>
+ */
 class Title extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Archive/Detectors/Title.php
+++ b/src/Adapters/Archive/Detectors/Title.php
@@ -12,8 +12,7 @@ class Title extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('metadata', 'title');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Archive/Extractor.php
+++ b/src/Adapters/Archive/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     private Api $api;
@@ -28,9 +31,6 @@ class Extractor extends Base
         return $this->api;
     }
 
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Bandcamp/Detectors/ProviderName.php
+++ b/src/Adapters/Bandcamp/Detectors/ProviderName.php
@@ -5,6 +5,9 @@ namespace Embed\Adapters\Bandcamp\Detectors;
 
 use Embed\Detectors\ProviderName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Bandcamp\Extractor>
+ */
 class ProviderName extends Detector
 {
     public function detect(): string

--- a/src/Adapters/Bandcamp/Extractor.php
+++ b/src/Adapters/Bandcamp/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Bandcamp;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/CadenaSer/Detectors/Code.php
+++ b/src/Adapters/CadenaSer/Detectors/Code.php
@@ -9,6 +9,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\CadenaSer\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/CadenaSer/Extractor.php
+++ b/src/Adapters/CadenaSer/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\CadenaSer;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Facebook/Detectors/Title.php
+++ b/src/Adapters/Facebook/Detectors/Title.php
@@ -5,6 +5,9 @@ namespace Embed\Adapters\Facebook\Detectors;
 
 use Embed\Detectors\Title as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Facebook\Extractor>
+ */
 class Title extends Detector
 {
     /**

--- a/src/Adapters/Facebook/Extractor.php
+++ b/src/Adapters/Facebook/Extractor.php
@@ -8,7 +8,7 @@ use Embed\Extractor as Base;
 class Extractor extends Base
 {
     /**
-     * @return array<string, \Embed\Detectors\Detector>
+     * @return array{title: Detectors\Title}
      */
     public function createCustomDetectors(): array
     {

--- a/src/Adapters/Flickr/Detectors/Code.php
+++ b/src/Adapters/Flickr/Detectors/Code.php
@@ -9,6 +9,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Flickr\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Flickr/Extractor.php
+++ b/src/Adapters/Flickr/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Flickr;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Gist/Detectors/AuthorName.php
+++ b/src/Adapters/Gist/Detectors/AuthorName.php
@@ -12,8 +12,7 @@ class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('owner');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Gist/Detectors/AuthorName.php
+++ b/src/Adapters/Gist/Detectors/AuthorName.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Gist\Detectors;
 
-use Embed\Adapters\Gist\Extractor;
 use Embed\Detectors\AuthorName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Gist\Extractor>
+ */
 class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Gist/Detectors/AuthorUrl.php
+++ b/src/Adapters/Gist/Detectors/AuthorUrl.php
@@ -3,15 +3,16 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Gist\Detectors;
 
-use Embed\Adapters\Gist\Extractor;
 use Embed\Detectors\AuthorUrl as Detector;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\Gist\Extractor>
+ */
 class AuthorUrl extends Detector
 {
     public function detect(): ?UriInterface
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
         $owner = $api->str('owner');

--- a/src/Adapters/Gist/Detectors/Code.php
+++ b/src/Adapters/Gist/Detectors/Code.php
@@ -20,8 +20,7 @@ class Code extends Detector
 
     private function fallback(): ?EmbedCode
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $code = $api->html('div');
         $stylesheet = $api->str('stylesheet');

--- a/src/Adapters/Gist/Detectors/Code.php
+++ b/src/Adapters/Gist/Detectors/Code.php
@@ -3,11 +3,13 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Gist\Detectors;
 
-use Embed\Adapters\Gist\Extractor;
 use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
 
+/**
+ * @extends Detector<\Embed\Adapters\Gist\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode
@@ -18,7 +20,6 @@ class Code extends Detector
 
     private function fallback(): ?EmbedCode
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Gist/Detectors/PublishedTime.php
+++ b/src/Adapters/Gist/Detectors/PublishedTime.php
@@ -13,8 +13,7 @@ class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->time('created_at');
         return $result !== null ? $result : parent::detect();

--- a/src/Adapters/Gist/Detectors/PublishedTime.php
+++ b/src/Adapters/Gist/Detectors/PublishedTime.php
@@ -4,14 +4,15 @@ declare(strict_types = 1);
 namespace Embed\Adapters\Gist\Detectors;
 
 use DateTime;
-use Embed\Adapters\Gist\Extractor;
 use Embed\Detectors\PublishedTime as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Gist\Extractor>
+ */
 class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Gist/Extractor.php
+++ b/src/Adapters/Gist/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     private Api $api;
@@ -28,9 +31,6 @@ class Extractor extends Base
         return $this->api;
     }
 
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Github/Detectors/Code.php
+++ b/src/Adapters/Github/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Github\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Github/Extractor.php
+++ b/src/Adapters/Github/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Github;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Ideone/Detectors/Code.php
+++ b/src/Adapters/Ideone/Detectors/Code.php
@@ -7,6 +7,9 @@ use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
 
+/**
+ * @extends Detector<\Embed\Adapters\Ideone\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Ideone/Extractor.php
+++ b/src/Adapters/Ideone/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Ideone;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/ImageShack/Detectors/AuthorName.php
+++ b/src/Adapters/ImageShack/Detectors/AuthorName.php
@@ -13,8 +13,7 @@ class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('owner', 'username');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/ImageShack/Detectors/AuthorName.php
+++ b/src/Adapters/ImageShack/Detectors/AuthorName.php
@@ -6,11 +6,13 @@ namespace Embed\Adapters\ImageShack\Detectors;
 use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\AuthorName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/ImageShack/Detectors/AuthorUrl.php
+++ b/src/Adapters/ImageShack/Detectors/AuthorUrl.php
@@ -3,15 +3,16 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\ImageShack\Detectors;
 
-use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\AuthorUrl as Detector;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class AuthorUrl extends Detector
 {
     public function detect(): ?UriInterface
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
         $owner = $api->str('owner', 'username');

--- a/src/Adapters/ImageShack/Detectors/Description.php
+++ b/src/Adapters/ImageShack/Detectors/Description.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\ImageShack\Detectors;
 
-use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\Description as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class Description extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/ImageShack/Detectors/Description.php
+++ b/src/Adapters/ImageShack/Detectors/Description.php
@@ -12,8 +12,7 @@ class Description extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('description');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/ImageShack/Detectors/Image.php
+++ b/src/Adapters/ImageShack/Detectors/Image.php
@@ -13,8 +13,7 @@ class Image extends Detector
 {
     public function detect(): ?UriInterface
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->url('direct_link');
         return $result !== null ? $result : parent::detect();

--- a/src/Adapters/ImageShack/Detectors/Image.php
+++ b/src/Adapters/ImageShack/Detectors/Image.php
@@ -3,15 +3,16 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\ImageShack\Detectors;
 
-use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\Image as Detector;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class Image extends Detector
 {
     public function detect(): ?UriInterface
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/ImageShack/Detectors/ProviderName.php
+++ b/src/Adapters/ImageShack/Detectors/ProviderName.php
@@ -5,6 +5,9 @@ namespace Embed\Adapters\ImageShack\Detectors;
 
 use Embed\Detectors\ProviderName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class ProviderName extends Detector
 {
     public function detect(): string

--- a/src/Adapters/ImageShack/Detectors/PublishedTime.php
+++ b/src/Adapters/ImageShack/Detectors/PublishedTime.php
@@ -14,8 +14,7 @@ class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->time('creation_date');
         return $result !== null ? $result : parent::detect();

--- a/src/Adapters/ImageShack/Detectors/PublishedTime.php
+++ b/src/Adapters/ImageShack/Detectors/PublishedTime.php
@@ -7,11 +7,13 @@ use DateTime;
 use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\PublishedTime as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/ImageShack/Detectors/Title.php
+++ b/src/Adapters/ImageShack/Detectors/Title.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\ImageShack\Detectors;
 
-use Embed\Adapters\ImageShack\Extractor;
 use Embed\Detectors\Title as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\ImageShack\Extractor>
+ */
 class Title extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/ImageShack/Detectors/Title.php
+++ b/src/Adapters/ImageShack/Detectors/Title.php
@@ -12,8 +12,7 @@ class Title extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('title');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/ImageShack/Extractor.php
+++ b/src/Adapters/ImageShack/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     private Api $api;
@@ -28,9 +31,6 @@ class Extractor extends Base
         return $this->api;
     }
 
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Instagram/Extractor.php
+++ b/src/Adapters/Instagram/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     public function __construct(UriInterface $uri, RequestInterface $request, ResponseInterface $response, Crawler $crawler)

--- a/src/Adapters/Pinterest/Detectors/Code.php
+++ b/src/Adapters/Pinterest/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Pinterest\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Pinterest/Extractor.php
+++ b/src/Adapters/Pinterest/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Pinterest;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Sassmeister/Detectors/Code.php
+++ b/src/Adapters/Sassmeister/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Sassmeister\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Sassmeister/Extractor.php
+++ b/src/Adapters/Sassmeister/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Sassmeister;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Slides/Detectors/Code.php
+++ b/src/Adapters/Slides/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
 
+/**
+ * @extends Detector<\Embed\Adapters\Slides\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): EmbedCode

--- a/src/Adapters/Slides/Extractor.php
+++ b/src/Adapters/Slides/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Slides;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Snipplr/Detectors/Code.php
+++ b/src/Adapters/Snipplr/Detectors/Code.php
@@ -8,6 +8,9 @@ use Embed\EmbedCode;
 use function Embed\html;
 use function Embed\matchPath;
 
+/**
+ * @extends Detector<\Embed\Adapters\Snipplr\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Snipplr/Extractor.php
+++ b/src/Adapters/Snipplr/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Snipplr;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Twitch/Detectors/Code.php
+++ b/src/Adapters/Twitch/Detectors/Code.php
@@ -7,6 +7,9 @@ use Embed\Detectors\Code as Detector;
 use Embed\EmbedCode;
 use function Embed\html;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitch\Extractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Adapters/Twitch/Extractor.php
+++ b/src/Adapters/Twitch/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Twitch;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Twitter/Detectors/AuthorName.php
+++ b/src/Adapters/Twitter/Detectors/AuthorName.php
@@ -13,8 +13,7 @@ class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('includes', 'users', '0', 'name');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Twitter/Detectors/AuthorName.php
+++ b/src/Adapters/Twitter/Detectors/AuthorName.php
@@ -6,11 +6,13 @@ namespace Embed\Adapters\Twitter\Detectors;
 use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\AuthorName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class AuthorName extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Twitter/Detectors/AuthorUrl.php
+++ b/src/Adapters/Twitter/Detectors/AuthorUrl.php
@@ -7,11 +7,13 @@ use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\AuthorUrl as Detector;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class AuthorUrl extends Detector
 {
     public function detect(): ?UriInterface
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
         $username = $api->str('includes', 'users', '0', 'username');

--- a/src/Adapters/Twitter/Detectors/Description.php
+++ b/src/Adapters/Twitter/Detectors/Description.php
@@ -6,11 +6,13 @@ namespace Embed\Adapters\Twitter\Detectors;
 use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\Description as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class Description extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Twitter/Detectors/Description.php
+++ b/src/Adapters/Twitter/Detectors/Description.php
@@ -13,8 +13,7 @@ class Description extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('data', 'text');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Twitter/Detectors/Image.php
+++ b/src/Adapters/Twitter/Detectors/Image.php
@@ -7,11 +7,13 @@ use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\Image as Detector;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class Image extends Detector
 {
     public function detect(): ?UriInterface
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
         $preview = $api->url('includes', 'media', '0', 'preview_image_url');

--- a/src/Adapters/Twitter/Detectors/Image.php
+++ b/src/Adapters/Twitter/Detectors/Image.php
@@ -14,8 +14,7 @@ class Image extends Detector
 {
     public function detect(): ?UriInterface
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
         $preview = $api->url('includes', 'media', '0', 'preview_image_url');
 
         if ($preview !== null) {

--- a/src/Adapters/Twitter/Detectors/ProviderName.php
+++ b/src/Adapters/Twitter/Detectors/ProviderName.php
@@ -5,6 +5,9 @@ namespace Embed\Adapters\Twitter\Detectors;
 
 use Embed\Detectors\ProviderName as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class ProviderName extends Detector
 {
     public function detect(): string

--- a/src/Adapters/Twitter/Detectors/PublishedTime.php
+++ b/src/Adapters/Twitter/Detectors/PublishedTime.php
@@ -7,11 +7,13 @@ use DateTime;
 use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\PublishedTime as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Twitter/Detectors/PublishedTime.php
+++ b/src/Adapters/Twitter/Detectors/PublishedTime.php
@@ -14,8 +14,7 @@ class PublishedTime extends Detector
 {
     public function detect(): ?DateTime
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->time('data', 'created_at');
         return $result !== null ? $result : parent::detect();

--- a/src/Adapters/Twitter/Detectors/Title.php
+++ b/src/Adapters/Twitter/Detectors/Title.php
@@ -13,8 +13,7 @@ class Title extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
         $name = $api->str('includes', 'users', '0', 'name');
 
         if ($name !== null) {

--- a/src/Adapters/Twitter/Detectors/Title.php
+++ b/src/Adapters/Twitter/Detectors/Title.php
@@ -6,11 +6,13 @@ namespace Embed\Adapters\Twitter\Detectors;
 use Embed\Adapters\Twitter\Extractor;
 use Embed\Detectors\Title as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Twitter\Extractor>
+ */
 class Title extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
         $name = $api->str('includes', 'users', '0', 'name');

--- a/src/Adapters/Twitter/Extractor.php
+++ b/src/Adapters/Twitter/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     private Api $api;
@@ -28,9 +31,6 @@ class Extractor extends Base
         return $this->api;
     }
 
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Wikipedia/Detectors/Description.php
+++ b/src/Adapters/Wikipedia/Detectors/Description.php
@@ -12,8 +12,7 @@ class Description extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('extract');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Wikipedia/Detectors/Description.php
+++ b/src/Adapters/Wikipedia/Detectors/Description.php
@@ -3,14 +3,15 @@ declare(strict_types = 1);
 
 namespace Embed\Adapters\Wikipedia\Detectors;
 
-use Embed\Adapters\Wikipedia\Extractor;
 use Embed\Detectors\Description as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Wikipedia\Extractor>
+ */
 class Description extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Wikipedia/Detectors/Title.php
+++ b/src/Adapters/Wikipedia/Detectors/Title.php
@@ -6,11 +6,13 @@ namespace Embed\Adapters\Wikipedia\Detectors;
 use Embed\Adapters\Wikipedia\Extractor;
 use Embed\Detectors\Title as Detector;
 
+/**
+ * @extends Detector<\Embed\Adapters\Wikipedia\Extractor>
+ */
 class Title extends Detector
 {
     public function detect(): ?string
     {
-        /** @var Extractor $extractor */
         $extractor = $this->extractor;
         $api = $extractor->getApi();
 

--- a/src/Adapters/Wikipedia/Detectors/Title.php
+++ b/src/Adapters/Wikipedia/Detectors/Title.php
@@ -13,8 +13,7 @@ class Title extends Detector
 {
     public function detect(): ?string
     {
-        $extractor = $this->extractor;
-        $api = $extractor->getApi();
+        $api = $this->extractor->getApi();
 
         $result = $api->str('title');
         return (is_string($result) && trim($result) !== '') ? $result : parent::detect();

--- a/src/Adapters/Wikipedia/Extractor.php
+++ b/src/Adapters/Wikipedia/Extractor.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
     private Api $api;
@@ -28,9 +31,6 @@ class Extractor extends Base
         return $this->api;
     }
 
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Adapters/Youtube/Detectors/Feeds.php
+++ b/src/Adapters/Youtube/Detectors/Feeds.php
@@ -8,6 +8,9 @@ use function Embed\getDirectory;
 use function Embed\matchPath;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @extends Detector<\Embed\Adapters\Youtube\Extractor>
+ */
 class Feeds extends Detector
 {
     /**

--- a/src/Adapters/Youtube/Extractor.php
+++ b/src/Adapters/Youtube/Extractor.php
@@ -5,11 +5,11 @@ namespace Embed\Adapters\Youtube;
 
 use Embed\Extractor as Base;
 
+/**
+ * @template-extends Base<\Embed\Detectors\Detector<self>>
+ */
 class Extractor extends Base
 {
-    /**
-     * @return array<string, \Embed\Detectors\Detector>
-     */
     public function createCustomDetectors(): array
     {
         return [

--- a/src/Detectors/AuthorName.php
+++ b/src/Detectors/AuthorName.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class AuthorName extends Detector
 {
     public function detect(): ?string

--- a/src/Detectors/AuthorUrl.php
+++ b/src/Detectors/AuthorUrl.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class AuthorUrl extends Detector
 {
     public function detect(): ?UriInterface

--- a/src/Detectors/Cms.php
+++ b/src/Detectors/Cms.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Cms extends Detector
 {
     public const BLOGSPOT = 'blogspot';

--- a/src/Detectors/Code.php
+++ b/src/Detectors/Code.php
@@ -6,6 +6,10 @@ namespace Embed\Detectors;
 use Embed\EmbedCode;
 use function Embed\html;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Code extends Detector
 {
     public function detect(): ?EmbedCode

--- a/src/Detectors/Description.php
+++ b/src/Detectors/Description.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Description extends Detector
 {
     public function detect(): ?string

--- a/src/Detectors/Detector.php
+++ b/src/Detectors/Detector.php
@@ -5,12 +5,19 @@ namespace Embed\Detectors;
 
 use Embed\Extractor;
 
+/**
+ * @template TExtractor of Extractor
+ */
 abstract class Detector
 {
+    /** @var TExtractor */
     protected Extractor $extractor;
     /** @var array<string, mixed> */
     private array $cache = [];
 
+    /**
+     * @param TExtractor $extractor
+     */
     public function __construct(Extractor $extractor)
     {
         $this->extractor = $extractor;

--- a/src/Detectors/Favicon.php
+++ b/src/Detectors/Favicon.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Favicon extends Detector
 {
     public function detect(): UriInterface

--- a/src/Detectors/Feeds.php
+++ b/src/Detectors/Feeds.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Feeds extends Detector
 {
     /** @var string[] */

--- a/src/Detectors/Icon.php
+++ b/src/Detectors/Icon.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Icon extends Detector
 {
     public function detect(): ?UriInterface

--- a/src/Detectors/Image.php
+++ b/src/Detectors/Image.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Image extends Detector
 {
     public function detect(): ?UriInterface

--- a/src/Detectors/Keywords.php
+++ b/src/Detectors/Keywords.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Keywords extends Detector
 {
     /**

--- a/src/Detectors/Language.php
+++ b/src/Detectors/Language.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Language extends Detector
 {
     public function detect(): ?string

--- a/src/Detectors/Languages.php
+++ b/src/Detectors/Languages.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use function Embed\isEmpty;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Languages extends Detector
 {
     /**

--- a/src/Detectors/License.php
+++ b/src/Detectors/License.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class License extends Detector
 {
     public function detect(): ?string

--- a/src/Detectors/ProviderName.php
+++ b/src/Detectors/ProviderName.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class ProviderName extends Detector
 {
     /** @var string[] */

--- a/src/Detectors/ProviderUrl.php
+++ b/src/Detectors/ProviderUrl.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class ProviderUrl extends Detector
 {
     public function detect(): UriInterface

--- a/src/Detectors/PublishedTime.php
+++ b/src/Detectors/PublishedTime.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use DateTime;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class PublishedTime extends Detector
 {
     public function detect(): ?DateTime

--- a/src/Detectors/Redirect.php
+++ b/src/Detectors/Redirect.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Redirect extends Detector
 {
     public function detect(): ?UriInterface

--- a/src/Detectors/Title.php
+++ b/src/Detectors/Title.php
@@ -3,6 +3,10 @@ declare(strict_types = 1);
 
 namespace Embed\Detectors;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Title extends Detector
 {
     public function detect(): ?string

--- a/src/Detectors/Url.php
+++ b/src/Detectors/Url.php
@@ -5,6 +5,10 @@ namespace Embed\Detectors;
 
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @template TExtractor of \Embed\Extractor
+ * @template-extends Detector<TExtractor>
+ */
 class Url extends Detector
 {
     public function detect(): UriInterface

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -53,6 +53,8 @@ use Psr\Http\Message\UriInterface;
  * @property UriInterface|null    $redirect
  * @property string|null          $title
  * @property UriInterface         $url
+ *
+ * @template TDetector of Detector = Detector
  */
 class Extractor
 {
@@ -68,27 +70,45 @@ class Extractor
 
     /** @var array<string, mixed> */
     private array $settings = [];
-    /** @var array<string, Detectors\Detector> */
+    /** @var array<string, Detectors\Detector<$this>> */
     private array $customDetectors = [];
-
+    /** @var AuthorName<$this> */
     protected AuthorName $authorName;
+    /** @var AuthorUrl<$this> */
     protected AuthorUrl $authorUrl;
+    /** @var Cms<$this> */
     protected Cms $cms;
+    /** @var Code<$this> */
     protected Code $code;
+    /** @var Description<$this> */
     protected Description $description;
+    /** @var Favicon<$this> */
     protected Favicon $favicon;
+    /** @var Feeds<$this> */
     protected Feeds $feeds;
+    /** @var Icon<$this> */
     protected Icon $icon;
+    /** @var Image<$this> */
     protected Image $image;
+    /** @var Keywords<$this> */
     protected Keywords $keywords;
+    /** @var Language<$this> */
     protected Language $language;
+    /** @var Languages<$this> */
     protected Languages $languages;
+    /** @var License<$this> */
     protected License $license;
+    /** @var ProviderName<$this> */
     protected ProviderName $providerName;
+    /** @var ProviderUrl<$this> */
     protected ProviderUrl $providerUrl;
+    /** @var PublishedTime<$this> */
     protected PublishedTime $publishedTime;
+    /** @var Redirect<$this> */
     protected Redirect $redirect;
+    /** @var Title<$this> */
     protected Title $title;
+    /** @var Url<$this> */
     protected Url $url;
 
     public function __construct(UriInterface $uri, RequestInterface $request, ResponseInterface $response, Crawler $crawler)
@@ -150,13 +170,16 @@ class Extractor
     }
 
     /**
-     * @return array<string, Detector>
+     * @return array<string, TDetector>
      */
     public function createCustomDetectors(): array
     {
         return [];
     }
 
+    /**
+     * @phpstan-param Detector<$this> $detector
+     */
     public function addDetector(string $name, Detector $detector): void
     {
         $this->customDetectors[$name] = $detector;

--- a/src/ExtractorFactory.php
+++ b/src/ExtractorFactory.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\UriInterface;
 
 class ExtractorFactory
 {
+    /** @var class-string<Extractor> */
     private string $default = Extractor::class;
     /** @var array<string, class-string<Extractor>> */
     private array $adapters = [
@@ -33,7 +34,7 @@ class ExtractorFactory
         'twitter.com' => Adapters\Twitter\Extractor::class,
         'x.com' => Adapters\Twitter\Extractor::class,
     ];
-    /** @var array<string, class-string<Detectors\Detector>> */
+    /** @var array<string, class-string<Detectors\Detector<Extractor>>> */
     private array $customDetectors = [];
     /** @var array<string, mixed> */
     private array $settings;
@@ -65,12 +66,10 @@ class ExtractorFactory
             }
         }
 
-        /** @var Extractor $extractor */
         $extractor = new $class($uri, $request, $response, $crawler);
         $extractor->setSettings($this->settings);
 
         foreach ($this->customDetectors as $name => $detectorClass) {
-            /** @var Detectors\Detector */
             $detector = new $detectorClass($extractor);
             $extractor->addDetector($name, $detector);
         }
@@ -91,7 +90,7 @@ class ExtractorFactory
     }
 
     /**
-     * @param class-string<Detectors\Detector> $class
+     * @param class-string<Detectors\Detector<Extractor>> $class
      */
     public function addDetector(string $name, string $class): void
     {
@@ -103,6 +102,9 @@ class ExtractorFactory
         unset($this->adapters[$pattern]);
     }
 
+    /**
+     * @param class-string<Extractor> $class
+     */
     public function setDefault(string $class): void
     {
         $this->default = $class;


### PR DESCRIPTION
Sadly, PR #562 introduces some inline `@var`
Using inline var is not encouraged.
https://phpstan.org/writing-php-code/phpdocs-basics#inline-%40var

## Summary

  This PR enhances type safety and code quality by adding PHPStan generic type annotations throughout the codebase and refactoring detector implementations to be more concise.

  - Add `@extends` and `@template-extends` generic type annotations to all Extractor and Detector classes across all adapters (Archive, Gist, ImageShack, Twitter, Wikipedia, Facebook, Github, Flickr, etc.)
  - Remove redundant intermediate `$extractor` variables in detector classes, accessing API directly via `$this->extractor->getApi()`
  - Simplify `createCustomDetectors()` return type annotations by leveraging generics

  ## Benefits

  - **Improved type safety**: PHPStan can now properly infer types through the generic inheritance chain
  - **Better IDE support**: Autocomplete and type hints work correctly with properly typed generics
  - **Cleaner code**: Eliminated unnecessary intermediate variables that added no value