### PR TITLE
Add code coverage configuration and CI integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,33 @@ jobs:
             - name: Tests
               run: composer test
 
+    coverage:
+        name: Code Coverage
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Install PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.4
+                  coverage: xdebug
+
+            - name: Cache PHP dependencies
+              uses: actions/cache@v4
+              with:
+                  path: vendor
+                  key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('**/composer.json') }}
+                  restore-keys: ${{ runner.os }}-php-8.4-composer-
+
+            - name: Install dependencies
+              run: composer install
+
+            - name: Run tests with coverage
+              run: composer coverage
+
     phpstan:
         name: PHPStan Static Analysis
         runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.cache
 *.code-workspace
 composer.lock
+coverage-html
 env.php
 phpunit.xml
 vendor

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,8 @@
     "scripts": {
         "demo": "php -S localhost:8888 demo/index.php",
         "test": "phpunit",
+        "coverage": "phpunit --coverage-text",
+        "coverage-report": "phpunit --coverage-html coverage-html",
         "cs-fix": "php-cs-fixer fix",
         "phpstan": "phpstan --memory-limit=-1",
         "update-resources": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,4 +22,12 @@
             <group>ignore</group>
         </exclude>
     </groups>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory>src/resources</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
- Add coverage configuration to phpunit.xml.dist
  - Include all src/ files except resources directory
  - Enable processUncoveredFiles for accurate coverage
- Add composer scripts for coverage measurement
  - `composer coverage`: CLI text output
  - `composer coverage-report`: HTML report to coverage-html/
- Add coverage-html/ to .gitignore
- Add GitHub Actions coverage job with Xdebug enabled
  - Runs on PHP 8.4
  - Executes coverage during CI pipeline