### PR TITLE
Access tokens are now optional with Meta

### DIFF
--- a/src/Adapters/Facebook/OEmbed.php
+++ b/src/Adapters/Facebook/OEmbed.php
@@ -8,17 +8,13 @@ use Psr\Http\Message\UriInterface;
 
 class OEmbed extends Base
 {
-    const ENDPOINT_PAGE = 'https://graph.facebook.com/v11.0/oembed_page';
-    const ENDPOINT_POST = 'https://graph.facebook.com/v11.0/oembed_post';
-    const ENDPOINT_VIDEO = 'https://graph.facebook.com/v11.0/oembed_video';
+    const ENDPOINT_PAGE = 'https://graph.facebook.com/v25.0/oembed_page';
+    const ENDPOINT_POST = 'https://graph.facebook.com/v25.0/oembed_post';
+    const ENDPOINT_VIDEO = 'https://graph.facebook.com/v25.0/oembed_video';
 
     protected function detectEndpoint(): ?UriInterface
     {
         $token = $this->extractor->getSetting('facebook:token');
-
-        if (!is_string($token) || $token === '') {
-            return null;
-        }
 
         $uri = $this->extractor->getUri();
         if (strpos($uri->getPath(), 'login') !== false) {
@@ -28,7 +24,7 @@ class OEmbed extends Base
             }
         }
         $queryParameters = $this->getOembedQueryParameters((string) $uri);
-        $queryParameters['access_token'] = $token;
+        if($token) $queryParameters['access_token'] = $token;
 
         return $this->extractor->getCrawler()
             ->createUri($this->getEndpointByPath($uri->getPath()))

--- a/src/Adapters/Instagram/OEmbed.php
+++ b/src/Adapters/Instagram/OEmbed.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\UriInterface;
 
 class OEmbed extends Base
 {
-    const ENDPOINT = 'https://graph.facebook.com/v8.0/instagram_oembed';
+    const ENDPOINT = 'https://graph.facebook.com/v25.0/instagram_oembed';
 
     protected function detectEndpoint(): ?UriInterface
     {

--- a/src/Adapters/Instagram/OEmbed.php
+++ b/src/Adapters/Instagram/OEmbed.php
@@ -14,17 +14,13 @@ class OEmbed extends Base
     {
         $token = $this->extractor->getSetting('instagram:token');
 
-        if (!is_string($token) || $token === '') {
-            return null;
-        }
-
         $uri = $this->extractor->getUri();
         if (strpos($uri->getPath(), 'login') !== false) {
             $uri = $this->extractor->getRequest()->getUri();
         }
 
         $queryParameters = $this->getOembedQueryParameters((string) $uri);
-        $queryParameters['access_token'] = $token;
+        if($token) $queryParameters['access_token'] = $token;
 
         return $this->extractor->getCrawler()
             ->createUri(self::ENDPOINT)


### PR DESCRIPTION
You no longer need access tokens to access Facebook or Instagram posts. This commit removes the requirements, and updates to v25.0 of their API.